### PR TITLE
Sanitize user URL input

### DIFF
--- a/src/app/components/settings-page/settings-page.component.ts
+++ b/src/app/components/settings-page/settings-page.component.ts
@@ -99,7 +99,7 @@ export class SettingsPageComponent implements OnInit {
     }
 
     addPluginEndpoint() {
-        const url = this.endpointUrl;
+        const url = this.endpointUrl?.trim();
         const type = this.endpointType ? this.endpointType : undefined;
         if (url) {
             this.backend.addPluginEndpoint(url, type).subscribe(() => {


### PR DESCRIPTION
When copying and pasting the URL for the plugin runner in the settings, it can happen that one accidentally leaves a trailing white space. If this happens, the mistake is overlooked easily and there is no connection from the backend to the plugin runner.

This is perhaps also useful for the backend URL and latex renderer URL.