### PR TITLE
fix download URL in experoiment data tab

### DIFF
--- a/src/app/components/experiment-data/experiment-data.component.html
+++ b/src/app/components/experiment-data/experiment-data.component.html
@@ -29,7 +29,7 @@
                     </div>
                     <div>
                         <dt>Dowload link</dt>
-                        <dd><a class="download-button" href="{{backendUrl}}{{data.download}}" target="_blank"
+                        <dd><a class="download-button" href="{{data.download}}" target="_blank"
                                 rel="noopener noreferrer" mat-flat-button>Dowload as File</a></dd>
                     </div>
                 </dl>


### PR DESCRIPTION
The download links in the Experiment -> Data tab don't seem to need the `backendURL` as prefix.

For me this broke the download links. E.g.

 `http://localhost:9090/http://host.docker.internal:9090/experiments/1/data/attr_dist.zip/download?version=1` 

instead of 

`http://host.docker.internal:9090/experiments/1/data/attr_dist.zip/download?version=1`