### PR TITLE
Fix API object subscriptions not being broadcast when cache is available

### DIFF
--- a/src/app/services/registry.service.ts
+++ b/src/app/services/registry.service.ts
@@ -196,10 +196,9 @@ export class PluginRegistryBaseService {
         }
     }
 
-    private async broadcastToSubscriptions(responseData: ApiResponse<unknown>) {
+    private async broadcastToSubscriptions(responseData: ApiResponse<unknown>, embedded?: Array<ApiResponse<unknown>>) {
         this.apiResponseSubject.next(responseData);
 
-        const embedded = responseData?.embedded;
         if (embedded != null) {
             for (const response of embedded) {
                 this.apiResponseSubject.next(response);
@@ -224,8 +223,9 @@ export class PluginRegistryBaseService {
             const responseData = await response.json() as T;
 
             if (isApiResponse(responseData)) {
+                const embedded = responseData?.embedded;
                 await this.cacheResults(input, responseData);
-                await this.broadcastToSubscriptions(responseData);
+                await this.broadcastToSubscriptions(responseData, embedded);
             }
 
             return responseData;

--- a/src/app/services/registry.service.ts
+++ b/src/app/services/registry.service.ts
@@ -144,14 +144,11 @@ export class PluginRegistryBaseService {
     }
 
 
-    private async cacheResults(request: RequestInfo, responseData: ApiResponse<unknown>) {
+    private async cacheResults(request: RequestInfo, responseData: ApiResponse<unknown>, embedded?: Array<ApiResponse<unknown>>) {
         if (this.apiCache == null) {
             return;
         }
         const isGet = typeof request === "string" || request.method === "GET";
-
-        const embedded = responseData?.embedded;
-        delete responseData.embedded; // nothing outside of caching must depend on this!
 
         if (isGet) {
             // only cache the whole response for get requests
@@ -224,7 +221,9 @@ export class PluginRegistryBaseService {
 
             if (isApiResponse(responseData)) {
                 const embedded = responseData?.embedded;
-                await this.cacheResults(input, responseData);
+                delete responseData.embedded; // nothing outside of caching must depend on this!
+
+                await this.cacheResults(input, responseData, embedded);
                 await this.broadcastToSubscriptions(responseData, embedded);
             }
 


### PR DESCRIPTION
When the cache is available, the `embedded` property of the `responseData` gets deleted in the `cacheResults` method, which caused the `broadcastToSubscriptions` method to not broadcast the embedded responses. This PR fixes this.