### PR TITLE
Fix builtin template "all-plugins" being deselected by accident

### DIFF
--- a/src/app/components/experiment-workspace-detail/experiment-workspace-detail.component.ts
+++ b/src/app/components/experiment-workspace-detail/experiment-workspace-detail.component.ts
@@ -27,6 +27,7 @@ export class ExperimentWorkspaceDetailComponent implements OnInit {
 
     templateId: string | null = null;
     tabId: string | null = null;
+    defaultTemplateId: string | null = null;
 
     templateObject: TemplateApiObject | null = null;
     tabObject: TemplateTabApiObject | null = null;
@@ -57,11 +58,13 @@ export class ExperimentWorkspaceDetailComponent implements OnInit {
     private changedTabSubscription: Subscription | null = null;
     private routeParamSubscription: Subscription | null = null;
 
+    private defaultTemplateIdSubscription: Subscription | null = null;
+
     constructor(private route: ActivatedRoute, private router: Router, private registry: PluginRegistryBaseService, private fb: FormBuilder, private dialog: MatDialog, private templates: TemplatesService) { }
 
     ngOnInit() {
         this.routeParamSubscription = this.route.queryParamMap.subscribe(async params => {
-            const templateId = params.get('template');
+            const templateId = params.get('template') ?? this.defaultTemplateId;
             const tabId = params.get('tab');
 
             if (templateId && templateId !== this.templateId) {
@@ -89,6 +92,7 @@ export class ExperimentWorkspaceDetailComponent implements OnInit {
         this.deletedTabSubscription?.unsubscribe();
         this.changedTabSubscription?.unsubscribe();
         this.routeParamSubscription?.unsubscribe();
+        this.defaultTemplateIdSubscription?.unsubscribe();
     }
 
     private sortTabs(group: string) {
@@ -188,6 +192,13 @@ export class ExperimentWorkspaceDetailComponent implements OnInit {
                     this.sortTabs(group);
                 }
             });
+
+        this.defaultTemplateIdSubscription = this.templates.defaultTemplateId.subscribe(defaultTemplateId => {
+            this.defaultTemplateId = defaultTemplateId;
+            if (this.templateId == null && this.defaultTemplateId != null) {
+                this.updateTemplateId(this.defaultTemplateId);
+            }
+        });
     }
 
     private async updateTemplateId(templateId: string) {

--- a/src/app/components/experiment-workspace-detail/experiment-workspace-detail.component.ts
+++ b/src/app/components/experiment-workspace-detail/experiment-workspace-detail.component.ts
@@ -27,7 +27,6 @@ export class ExperimentWorkspaceDetailComponent implements OnInit {
 
     templateId: string | null = null;
     tabId: string | null = null;
-    defaultTemplateId: string | null = null;
 
     templateObject: TemplateApiObject | null = null;
     tabObject: TemplateTabApiObject | null = null;
@@ -58,13 +57,11 @@ export class ExperimentWorkspaceDetailComponent implements OnInit {
     private changedTabSubscription: Subscription | null = null;
     private routeParamSubscription: Subscription | null = null;
 
-    private defaultTemplateIdSubscription: Subscription | null = null;
-
     constructor(private route: ActivatedRoute, private router: Router, private registry: PluginRegistryBaseService, private fb: FormBuilder, private dialog: MatDialog, private templates: TemplatesService) { }
 
     ngOnInit() {
         this.routeParamSubscription = this.route.queryParamMap.subscribe(async params => {
-            const templateId = params.get('template') ?? this.defaultTemplateId;
+            const templateId = params.get('template');
             const tabId = params.get('tab');
 
             if (templateId && templateId !== this.templateId) {
@@ -92,7 +89,6 @@ export class ExperimentWorkspaceDetailComponent implements OnInit {
         this.deletedTabSubscription?.unsubscribe();
         this.changedTabSubscription?.unsubscribe();
         this.routeParamSubscription?.unsubscribe();
-        this.defaultTemplateIdSubscription?.unsubscribe();
     }
 
     private sortTabs(group: string) {
@@ -192,13 +188,6 @@ export class ExperimentWorkspaceDetailComponent implements OnInit {
                     this.sortTabs(group);
                 }
             });
-
-        this.defaultTemplateIdSubscription = this.templates.defaultTemplateId.subscribe(defaultTemplateId => {
-            this.defaultTemplateId = defaultTemplateId;
-            if (this.templateId == null && this.defaultTemplateId != null) {
-                this.updateTemplateId(this.defaultTemplateId);
-            }
-        });
     }
 
     private async updateTemplateId(templateId: string) {

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -5,32 +5,32 @@
     </a>
 
     <ng-container *ngIf="(currentExperiment|async) != null">
-        <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'info']" [queryParams]="{template: templateId}"
-            routerLinkActive="active">
+        <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'info']"
+            [queryParams]="{template: routeTemplateId}" routerLinkActive="active">
             Info
         </a>
-        <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'workspace']" [queryParams]="{template: templateId}"
-            routerLinkActive="active">
+        <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'workspace']"
+            [queryParams]="{template: routeTemplateId}" routerLinkActive="active">
             Workspace
         </a>
-        <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'data']" [queryParams]="{template: templateId}"
-            routerLinkActive="active">
+        <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'data']"
+            [queryParams]="{template: routeTemplateId}" routerLinkActive="active">
             Data
         </a>
-        <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'timeline']" [queryParams]="{template: templateId}"
-            routerLinkActive="active">
+        <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'timeline']"
+            [queryParams]="{template: routeTemplateId}" routerLinkActive="active">
             Timeline
         </a>
         <a class="navigation-link" mat-button
-            [routerLink]="['/experiments', (experimentId|async), 'extra', tab.resourceKey?.uiTemplateTabId]" [queryParams]="{template: templateId}"
-            routerLinkActive="active" *ngFor="let tab of experimentExtraTabs">
+            [routerLink]="['/experiments', (experimentId|async), 'extra', tab.resourceKey?.uiTemplateTabId]"
+            [queryParams]="{template: routeTemplateId}" routerLinkActive="active"
+            *ngFor="let tab of experimentExtraTabs">
             {{tab.name}}
         </a>
     </ng-container>
     <ng-container *ngIf="(currentExperiment|async) == null">
-        <a class="navigation-link" mat-button
-            [routerLink]="['extra', tab.resourceKey?.uiTemplateTabId]" [queryParams]="{template: templateId}"
-            routerLinkActive="active" *ngFor="let tab of generalExtraTabs">
+        <a class="navigation-link" mat-button [routerLink]="['extra', tab.resourceKey?.uiTemplateTabId]"
+            [queryParams]="{template: routeTemplateId}" routerLinkActive="active" *ngFor="let tab of generalExtraTabs">
             {{tab.name}}
         </a>
     </ng-container>

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -48,9 +48,12 @@ export class NavbarComponent implements OnInit, OnDestroy {
     templateId: string | null = null;
     template: TemplateApiObject | null = null;
 
-    private defaultTemplateIdSubscription: Subscription | null = null;
-    private defaultTemplateSubscription: Subscription | null = null;
+    routeTemplateId: string | null = null;
+
+    private currentTemplateIdSubscription: Subscription | null = null;
+    private currentTemplateSubscription: Subscription | null = null;
     private templateTabUpdatesSubscription: Subscription | null = null;
+    private routeParamsSubscription: Subscription | null = null;
 
     constructor(private route: ActivatedRoute, private experiment: CurrentExperimentService, private templates: TemplatesService, private registry: PluginRegistryBaseService, private backend: QhanaBackendService, private downloadService: DownloadsService) {
         this.currentExperiment = this.experiment.experimentName;
@@ -64,14 +67,17 @@ export class NavbarComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy(): void {
-        this.defaultTemplateIdSubscription?.unsubscribe();
-        this.defaultTemplateSubscription?.unsubscribe();
+        this.currentTemplateIdSubscription?.unsubscribe();
+        this.currentTemplateSubscription?.unsubscribe();
         this.templateTabUpdatesSubscription?.unsubscribe();
+        this.routeParamsSubscription?.unsubscribe();
     }
 
     private registerSubscriptions() {
-        this.defaultTemplateIdSubscription = this.templates.currentTemplateId.subscribe(templateId => this.templateId = templateId);
-        this.defaultTemplateSubscription = this.templates.currentTemplate.subscribe(template => {
+        this.routeParamsSubscription = this.route.queryParamMap.subscribe(params => this.routeTemplateId = params.get('template'));
+
+        this.currentTemplateIdSubscription = this.templates.currentTemplateId.subscribe(templateId => this.templateId = templateId);
+        this.currentTemplateSubscription = this.templates.currentTemplate.subscribe(template => {
             this.onTemplateChanges(template);
         });
         this.templateTabUpdatesSubscription = this.templates.currentTemplateTabsUpdates.subscribe(() => {

--- a/src/app/components/plugin-sidebar/plugin-sidebar.component.html
+++ b/src/app/components/plugin-sidebar/plugin-sidebar.component.html
@@ -55,7 +55,7 @@
         </div>
         <div class="template-tab-sidebar" [hidden]="activeArea != 'detail'">
             <mat-divider></mat-divider>
-            <qhana-tab-group-list [templateId]="templateId" [selectedTab]="tabId"
+            <qhana-tab-group-list [templateId]="templateId ?? defaultTemplateId" [selectedTab]="tabId"
                 (clickedOnTab)="selectTab($event)"></qhana-tab-group-list>
         </div>
         <details class="plugin-group" [open]="group.open" *ngFor="let group of pluginGroups"

--- a/src/app/components/plugin-sidebar/plugin-sidebar.component.html
+++ b/src/app/components/plugin-sidebar/plugin-sidebar.component.html
@@ -55,7 +55,7 @@
         </div>
         <div class="template-tab-sidebar" [hidden]="activeArea != 'detail'">
             <mat-divider></mat-divider>
-            <qhana-tab-group-list [templateId]="effectiveTemplateId" [selectedTab]="tabId"
+            <qhana-tab-group-list [templateId]="templateId" [selectedTab]="tabId"
                 (clickedOnTab)="selectTab($event)"></qhana-tab-group-list>
         </div>
         <details class="plugin-group" [open]="group.open" *ngFor="let group of pluginGroups"

--- a/src/app/components/plugin-sidebar/plugin-sidebar.component.html
+++ b/src/app/components/plugin-sidebar/plugin-sidebar.component.html
@@ -55,7 +55,7 @@
         </div>
         <div class="template-tab-sidebar" [hidden]="activeArea != 'detail'">
             <mat-divider></mat-divider>
-            <qhana-tab-group-list [templateId]="templateId" [selectedTab]="tabId"
+            <qhana-tab-group-list [templateId]="effectiveTemplateId" [selectedTab]="tabId"
                 (clickedOnTab)="selectTab($event)"></qhana-tab-group-list>
         </div>
         <details class="plugin-group" [open]="group.open" *ngFor="let group of pluginGroups"

--- a/src/app/components/plugin-sidebar/plugin-sidebar.component.ts
+++ b/src/app/components/plugin-sidebar/plugin-sidebar.component.ts
@@ -66,7 +66,8 @@ export class PluginSidebarComponent implements OnInit, OnDestroy {
             // and external default templates should not be used
             return this.templateId ?? ALL_PLUGINS_TEMPLATE_ID;
         }
-        return this.templateId;
+        const defaultTemplateId = this.defaultTemplate?.self?.resourceKey?.uiTemplateId ?? null
+        return this.templateId ?? defaultTemplateId;
     }
 
     @ViewChild('searchInput', { static: true }) searchInput: ElementRef<HTMLInputElement> | null = null;

--- a/src/app/components/plugin-sidebar/plugin-sidebar.component.ts
+++ b/src/app/components/plugin-sidebar/plugin-sidebar.component.ts
@@ -19,6 +19,9 @@ export interface PluginGroup {
 }
 
 
+const ALL_PLUGINS_TEMPLATE_ID = "all-plugins";
+
+
 @Component({
     selector: 'qhana-plugin-sidebar',
     templateUrl: './plugin-sidebar.component.html',
@@ -57,6 +60,13 @@ export class PluginSidebarComponent implements OnInit, OnDestroy {
     private deletedTabSubscription: Subscription | null = null;
     private changedTemplateSubscription: Subscription | null = null;
 
+    get effectiveTemplateId(): string | null {
+        if (this.useDefaultTemplate) {
+            return ALL_PLUGINS_TEMPLATE_ID;
+        }
+        return this.templateId;
+    }
+
     @ViewChild('searchInput', { static: true }) searchInput: ElementRef<HTMLInputElement> | null = null;
 
     constructor(private route: ActivatedRoute, private router: Router, private templates: TemplatesService, private registry: PluginRegistryBaseService, private dialog: MatDialog) { }
@@ -64,8 +74,8 @@ export class PluginSidebarComponent implements OnInit, OnDestroy {
     ngOnInit(): void {
         this.routeParamSubscription = this.route.queryParamMap.subscribe(params => {
             let templateId = params.get('template');
-            this.useDefaultTemplate = templateId !== "all-plugins";
-            if (templateId === "all-plugins") {
+            this.useDefaultTemplate = templateId !== ALL_PLUGINS_TEMPLATE_ID;
+            if (templateId === ALL_PLUGINS_TEMPLATE_ID) {
                 templateId = null;
             }
             this.templateId = templateId;
@@ -316,9 +326,9 @@ export class PluginSidebarComponent implements OnInit, OnDestroy {
         }
 
         if (this.activeArea === 'detail' && newArea !== 'detail') {
-            this.navigate(this.templateId, this.pluginId, null);
+            this.navigate(this.effectiveTemplateId, this.pluginId, null);
         } else if (this.activeArea !== 'detail' && newArea === 'detail') {
-            this.navigate(this.templateId, null, this.tabId ?? 'new');
+            this.navigate(this.effectiveTemplateId, null, this.tabId ?? 'new');
         }
 
         this.sidebarOpen = true;
@@ -355,7 +365,7 @@ export class PluginSidebarComponent implements OnInit, OnDestroy {
         }
     }
 
-    selectTemplate(templateLink: ApiLink | null, specialTemplateId: "all-plugins" | null = null) {
+    selectTemplate(templateLink: ApiLink | null, specialTemplateId: (typeof ALL_PLUGINS_TEMPLATE_ID) | null = null) {
         this.useDefaultTemplate = specialTemplateId == null;
 
         this.switchActiveTemplateLink(templateLink);
@@ -373,7 +383,7 @@ export class PluginSidebarComponent implements OnInit, OnDestroy {
                 // double click deselects plugin
                 pluginId = null;
             }
-            this.navigate(this.templateId, pluginId, null);
+            this.navigate(this.effectiveTemplateId, pluginId, null);
         }
         this.activeArea = "plugins";
         this.sidebarOpen = pluginId == null; // always close sidebar after successfully selecting plugin
@@ -393,7 +403,7 @@ export class PluginSidebarComponent implements OnInit, OnDestroy {
                 console.warn("The template id in the given link does not match the selected template id!", tabLink);
             }
         }
-        this.navigate(templateId, null, tabId);
+        this.navigate(this.effectiveTemplateId, null, tabId);
     }
 
     async createTemplate() {

--- a/src/app/components/plugin-sidebar/plugin-sidebar.component.ts
+++ b/src/app/components/plugin-sidebar/plugin-sidebar.component.ts
@@ -66,8 +66,7 @@ export class PluginSidebarComponent implements OnInit, OnDestroy {
             // and external default templates should not be used
             return this.templateId ?? ALL_PLUGINS_TEMPLATE_ID;
         }
-        const defaultTemplateId = this.defaultTemplate?.self?.resourceKey?.uiTemplateId ?? null
-        return this.templateId ?? defaultTemplateId;
+        return this.templateId;
     }
 
     @ViewChild('searchInput', { static: true }) searchInput: ElementRef<HTMLInputElement> | null = null;


### PR DESCRIPTION
Fixes #49

Navigation to plugins and tabs only used the internal `templateId` and ignored the new flag for the builtin default plugins template. Solved by introducing an `effectiveTemplateId` getter for navigation.

I have not tested the fix locally, but I am pretty sure it should work... (do not merge without actually testing the fix)