### PR TITLE
default template sidebar reload

### DIFF
--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -5,8 +5,7 @@
     </a>
 
     <ng-container *ngIf="(currentExperiment|async) != null">
-        <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'info']"
-            [queryParams]="{template: routeTemplateId}" routerLinkActive="active">
+        <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'info']" routerLinkActive="active">
             Info
         </a>
         <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'workspace']"

--- a/src/app/components/plugin-sidebar/plugin-sidebar.component.ts
+++ b/src/app/components/plugin-sidebar/plugin-sidebar.component.ts
@@ -108,7 +108,7 @@ export class PluginSidebarComponent implements OnInit, OnDestroy {
                     this.switchActiveArea("plugins");
                 }
             }
-            this.loadActiveTemplateFromId(this.templateId);
+            this.loadActiveTemplateFromId(this.templateId ?? this.defaultTemplateId);
         });
 
         this.registry.resolveRecursiveRels([["plugin", "collection"]]).then((apiLink) => {


### PR DESCRIPTION
This PR contains 2 improvements:
- Without template URL parameter the plugin sidebar (experiment workspace tab) is always reloaded when the user selects a plugin. This PR stops the plugin sidebar from reloading when not necessary.
- When navigating to the experiment info tab the template URL parameter persists. This might be undesirable when the user navigates back and forth between the info and the workspace tab with a default template set. In this PR the template URL parameter is removed when navigating to the experiment info tab.