### PR TITLE
Refactor timeline step details

### DIFF
--- a/src/app/components/preview-list/preview-list.component.html
+++ b/src/app/components/preview-list/preview-list.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngFor="let data of resolvedDataList">
+<ng-container *ngFor="let data of resolvedDataList; trackBy: trackByFn">
     <qhana-data-preview [data]="data">
         <a [routerLink]="['/experiments', experimentId, 'data', data.name, {version: data.version}]">
             <h5>{{data.name}} (version {{data.version}})</h5>

--- a/src/app/components/timeline-step/timeline-step.component.html
+++ b/src/app/components/timeline-step/timeline-step.component.html
@@ -81,16 +81,19 @@
                     <dd>{{timelineStep.processorLocation}}</dd>
                 </div>
             </dl>
-            <details class="collapsible-item" [open]="timelineStep.status === 'PENDING'">
-                <summary class="summary-item">Result Log</summary>
-                {{timelineStep.resultLog}}
-            </details>
-            <details class="collapsible-item">
-                <summary class="summary-item">Parameters</summary>
-                <qhana-data-preview [data]="timelineStep"></qhana-data-preview>
-            </details>
         </mat-card-content>
     </mat-card>
+
+    <mat-expansion-panel class="result-log" [expanded]="timelineStep.status === 'PENDING'"
+        *ngIf="stepTabId === 'overview'">
+        <mat-expansion-panel-header>
+            <mat-panel-title>
+                Result Log
+            </mat-panel-title>
+        </mat-expansion-panel-header>
+        <pre>{{timelineStep.resultLog}}</pre>
+    </mat-expansion-panel>
+
     <div class="notes-title" *ngIf="stepTabId === 'overview' && timelineStep.status !== 'PENDING'">
         <h2>Notes</h2>
         <div class="notes-status" *ngIf="notesStatus === 'changed'">
@@ -112,10 +115,12 @@
             </mat-spinner>
         </mat-card-content>
     </mat-card>
-    <mat-card class="recommendation-card card" *ngIf="stepTabId === 'overview' && timelineStep.status !== 'PENDING' && pluginRecommendations.length != 0">
+    <mat-card class="recommendation-card card"
+        *ngIf="stepTabId === 'overview' && timelineStep.status !== 'PENDING' && pluginRecommendations.length != 0">
         <mat-card-title class="t-headline">Plugin Recommendations</mat-card-title>
         <mat-card-content>
-            <a *ngFor="let plugin of pluginRecommendations" [routerLink]="['/experiments', experimentId, 'workspace']" [queryParams]="{'plugin': plugin.resourceKey?.pluginId}">
+            <a *ngFor="let plugin of pluginRecommendations" [routerLink]="['/experiments', experimentId, 'workspace']"
+                [queryParams]="{'plugin': plugin.resourceKey?.pluginId}">
                 <qhana-plugin-list-item [link]="plugin"></qhana-plugin-list-item>
             </a>
         </mat-card-content>
@@ -126,7 +131,9 @@
         <qhana-preview-list [dataList]="timelineStep.outputData"></qhana-preview-list>
     </ng-container>
     <ng-container *ngIf="stepTabId === 'inputs' && timelineStep.inputData != null && timelineStep.inputData.length > 0">
-        <h2>Input</h2>
+        <h2>Parameters</h2>
+        <qhana-data-preview [data]="timelineStep"></qhana-data-preview>
+        <h2>Data Input</h2>
         <qhana-preview-list [dataList]="timelineStep.inputData"></qhana-preview-list>
     </ng-container>
 

--- a/src/app/components/timeline-step/timeline-step.component.html
+++ b/src/app/components/timeline-step/timeline-step.component.html
@@ -91,7 +91,7 @@
                 Result Log
             </mat-panel-title>
         </mat-expansion-panel-header>
-        <pre>{{timelineStep.resultLog}}</pre>
+        <pre class="log-text">{{timelineStep.resultLog}}</pre>
     </mat-expansion-panel>
 
     <div class="notes-title" *ngIf="stepTabId === 'overview' && timelineStep.status !== 'PENDING'">

--- a/src/app/components/timeline-step/timeline-step.component.sass
+++ b/src/app/components/timeline-step/timeline-step.component.sass
@@ -7,6 +7,9 @@
 .step-card
     margin-block-start: 0.8rem
 
+.result-log
+    margin-block: 1rem
+
 .notes-card
     margin-block-end: 1rem
 

--- a/src/app/components/timeline-step/timeline-step.component.sass
+++ b/src/app/components/timeline-step/timeline-step.component.sass
@@ -10,6 +10,11 @@
 .result-log
     margin-block: 1rem
 
+.log-text
+    overflow: auto
+    //white-space: pre-wrap
+    //overflow-wrap: anywhere
+
 .notes-card
     margin-block-end: 1rem
 


### PR DESCRIPTION
Fix timeline step autoreload always refreshing data inputs.
Move result log and parameters into their own cards (parameters are now under inputs)