### PR TITLE
Feature: plugin id filters

### DIFF
--- a/src/app/components-small/plugin-filter-editor/plugin-filter-editor.component.html
+++ b/src/app/components-small/plugin-filter-editor/plugin-filter-editor.component.html
@@ -30,6 +30,7 @@
                 <dt>name</dt> <dd>Filters for a plugin name.</dd>
                 <dt>tag</dt> <dd>Allows filtering elements by their assigned tags.</dd>
                 <dt>version</dt> <dd>Uses PEP 440 version specifier to filter elements based on specific versions or version ranges.</dd>
+                <dt>type</dt> <dd>Filters for plugin types (e.g. processing, visualization, ...)</dd>
                 <dt>not</dt> <dd>Specifies a filter string to exclude certain elements.</dd>
                 <dt>and</dt> <dd>Includes multiple filter strings, with elements passing all conditions included in the filtered results (intersection).</dd>
                 <dt>or</dt> <dd>Includes multiple filter strings, with elements meeting at least one condition included in the filtered results (union).</dd>

--- a/src/app/components-small/plugin-filter-editor/plugin-filter-editor.component.html
+++ b/src/app/components-small/plugin-filter-editor/plugin-filter-editor.component.html
@@ -26,7 +26,8 @@
             
             <i>Enter a filter string as JSON object. Filter strings have the following keys:</i>
             <dl>
-                <dt>name</dt> <dd>Represents the name of a plugin.</dd>
+                <dt>id</dt> <dd>Filters for a plugin id (without version).</dd>
+                <dt>name</dt> <dd>Filters for a plugin name.</dd>
                 <dt>tag</dt> <dd>Allows filtering elements by their assigned tags.</dd>
                 <dt>version</dt> <dd>Uses PEP 440 version specifier to filter elements based on specific versions or version ranges.</dd>
                 <dt>not</dt> <dd>Specifies a filter string to exclude certain elements.</dd>

--- a/src/app/components-small/plugin-filter-editor/plugin-filter-editor.component.html
+++ b/src/app/components-small/plugin-filter-editor/plugin-filter-editor.component.html
@@ -26,7 +26,7 @@
             
             <i>Enter a filter string as JSON object. Filter strings have the following keys:</i>
             <dl>
-                <dt>id</dt> <dd>Filters for a plugin id (without version).</dd>
+                <dt>id</dt> <dd>Filters for a plugin id (<code>@&lt;version&gt;</code> not required).</dd>
                 <dt>name</dt> <dd>Filters for a plugin name.</dd>
                 <dt>tag</dt> <dd>Allows filtering elements by their assigned tags.</dd>
                 <dt>version</dt> <dd>Uses PEP 440 version specifier to filter elements based on specific versions or version ranges.</dd>

--- a/src/app/components-small/plugin-filter-node/plugin-filter-node.component.html
+++ b/src/app/components-small/plugin-filter-node/plugin-filter-node.component.html
@@ -56,6 +56,7 @@
                         <mat-option value="name">Name</mat-option>
                         <mat-option value="tag">Tag</mat-option>
                         <mat-option value="version">Version</mat-option>
+                        <mat-option value="type">Type</mat-option>
                     </mat-select>
                 </mat-form-field>
                 <mat-form-field class="form-field">

--- a/src/app/components-small/plugin-filter-node/plugin-filter-node.component.html
+++ b/src/app/components-small/plugin-filter-node/plugin-filter-node.component.html
@@ -52,6 +52,7 @@
                 <mat-form-field class="inner-form-field">
                     <mat-label>Filter Type:</mat-label>
                     <mat-select [value]="type" (valueChange)="changeType($event)">
+                        <mat-option value="id">Plugin ID</mat-option>
                         <mat-option value="name">Name</mat-option>
                         <mat-option value="tag">Tag</mat-option>
                         <mat-option value="version">Version</mat-option>

--- a/src/app/components-small/plugin-filter-node/plugin-filter-node.component.html
+++ b/src/app/components-small/plugin-filter-node/plugin-filter-node.component.html
@@ -61,8 +61,14 @@
                 </mat-form-field>
                 <mat-form-field class="form-field">
                     <mat-label>Filter String:</mat-label>
-                    <textarea matInput [value]="value" (focusout)="updateFilterString($event)" cdkTextareaAutosize #autosize="cdkTextareaAutosize"
-                    cdkAutosizeMinRows="1" cdkAutosizeMaxRows="15"></textarea>
+                    <input matInput [value]="value" (focusout)="updateFilterString($event)" list="plugin-types">
+                    <datalist *ngIf="type === 'type'" id="plugin-types">
+                        <option value="processing"></option>
+                        <option value="visualization"></option>
+                        <option value="conversion"></option>
+                        <option value="dataloader"></option>
+                        <option value="interaction"></option>
+                    </datalist>
                 </mat-form-field>
                 <button mat-raised-button type="button" (click)="delete.emit()">
                     <mat-icon>delete</mat-icon>

--- a/src/app/components-small/plugin-filter-node/plugin-filter-node.component.ts
+++ b/src/app/components-small/plugin-filter-node/plugin-filter-node.component.ts
@@ -3,7 +3,7 @@ import { Component, EventEmitter, Input, OnInit, Output, SimpleChanges } from '@
 // Define filter types ('not' excluded)
 // The PluginFilterNodeComponent component is designed to encapsulate a filter object and the information wether the filter is inverted ('not').
 // When the filter is inverted, the filter object is wrapped in a 'not' object and the 'inverted' property is set to true.
-const filterTypes = ['and', 'or', 'name', 'tag', 'version'] as const;
+const filterTypes = ['and', 'or', 'id', 'name', 'tag', 'version'] as const;
 type FilterType = (typeof filterTypes)[number];
 const isFilterType = (x: any): x is FilterType => filterTypes.includes(x);
 

--- a/src/app/components-small/plugin-filter-node/plugin-filter-node.component.ts
+++ b/src/app/components-small/plugin-filter-node/plugin-filter-node.component.ts
@@ -3,7 +3,7 @@ import { Component, EventEmitter, Input, OnInit, Output, SimpleChanges } from '@
 // Define filter types ('not' excluded)
 // The PluginFilterNodeComponent component is designed to encapsulate a filter object and the information wether the filter is inverted ('not').
 // When the filter is inverted, the filter object is wrapped in a 'not' object and the 'inverted' property is set to true.
-const filterTypes = ['and', 'or', 'id', 'name', 'tag', 'version'] as const;
+const filterTypes = ['and', 'or', 'id', 'name', 'tag', 'version', 'type'] as const;
 type FilterType = (typeof filterTypes)[number];
 const isFilterType = (x: any): x is FilterType => filterTypes.includes(x);
 


### PR DESCRIPTION
Add plugin id filters to the plugin filter editor.

Requires https://github.com/UST-QuAntiL/qhana-plugin-registry/pull/26

Related to https://github.com/UST-QuAntiL/qhana-plugin-registry/issues/24