### PR TITLE
fix: keep URL params when navigating

### DIFF
--- a/src/app/components/data-detail/data-detail.component.html
+++ b/src/app/components/data-detail/data-detail.component.html
@@ -1,7 +1,7 @@
 <div class="big-content" *ngIf="data != null">
     <div class="title">
         <h1 class="t-page-headline">Data</h1>
-        <a mat-icon-button aria-label="back to data list" [routerLink]="['/experiments', experimentId, 'data']" queryParamsHandling="preserve">
+        <a mat-icon-button aria-label="back to data list" [routerLink]="['/experiments', experimentId, 'data']" queryParamsHandling="merge">
             <mat-icon>arrow_back</mat-icon>
         </a>
     </div>

--- a/src/app/components/data-detail/data-detail.component.html
+++ b/src/app/components/data-detail/data-detail.component.html
@@ -1,7 +1,7 @@
 <div class="big-content" *ngIf="data != null">
     <div class="title">
         <h1 class="t-page-headline">Data</h1>
-        <a mat-icon-button aria-label="back to data list" [routerLink]="['/experiments', experimentId, 'data']">
+        <a mat-icon-button aria-label="back to data list" [routerLink]="['/experiments', experimentId, 'data']" queryParamsHandling="preserve">
             <mat-icon>arrow_back</mat-icon>
         </a>
     </div>
@@ -33,7 +33,7 @@
                 <div *ngIf="data?.producedBy != null">
                     <dt>Created in</dt>
                     <dd>
-                        <a [routerLink]="['/experiments', experimentId, 'timeline', data.producedBy]">
+                        <a [routerLink]="['/experiments', experimentId, 'timeline', data.producedBy]" queryParamsHandling="merge">
                             Step {{data.producedBy}}
                         </a>
                     </dd>

--- a/src/app/components/experiment-data/experiment-data.component.html
+++ b/src/app/components/experiment-data/experiment-data.component.html
@@ -35,7 +35,7 @@
         </mat-card>
         <mat-card appearance="outlined" class="page-item card" *ngFor="let data of experimentData | async">
             <mat-card-title>
-                <a class="t-headline title-link"
+                <a class="t-headline title-link" queryParamsHandling="merge"
                     [routerLink]="['/experiments', experimentId, 'data', data.name, {version: data.version.toString()}]">{{data.name}}</a>
             </mat-card-title>
             <mat-card-content>

--- a/src/app/components/experiment-timeline/experiment-timeline.component.html
+++ b/src/app/components/experiment-timeline/experiment-timeline.component.html
@@ -67,7 +67,7 @@
         <mat-card appearance="outlined" class="page-item card" *ngFor="let step of timelineSteps | async">
             <mat-card-title>
                 <a class="t-headline title-link"
-                    [routerLink]="['/experiments', experimentId, 'timeline', step.sequence]" queryParamsHandling="preserve">
+                    [routerLink]="['/experiments', experimentId, 'timeline', step.sequence]" queryParamsHandling="merge">
                     Step {{step.sequence}} ({{step.processorName}}@{{step.processorVersion}})
                 </a>
                 <qhana-step-status [step]="step" [noText]="step.status !== 'PENDING'" [spinner]="0"></qhana-step-status>

--- a/src/app/components/experiment-timeline/experiment-timeline.component.html
+++ b/src/app/components/experiment-timeline/experiment-timeline.component.html
@@ -67,7 +67,7 @@
         <mat-card appearance="outlined" class="page-item card" *ngFor="let step of timelineSteps | async">
             <mat-card-title>
                 <a class="t-headline title-link"
-                    [routerLink]="['/experiments', experimentId, 'timeline', step.sequence]">
+                    [routerLink]="['/experiments', experimentId, 'timeline', step.sequence]" queryParamsHandling="preserve">
                     Step {{step.sequence}} ({{step.processorName}}@{{step.processorVersion}})
                 </a>
                 <qhana-step-status [step]="step" [noText]="step.status !== 'PENDING'" [spinner]="0"></qhana-step-status>

--- a/src/app/components/experiment-workspace/experiment-workspace.component.ts
+++ b/src/app/components/experiment-workspace/experiment-workspace.component.ts
@@ -100,6 +100,6 @@ export class ExperimentWorkspaceComponent implements OnInit, OnDestroy {
             processorName: plugin.identifier,
             processorVersion: plugin.version,
             resultLocation: formData.resultUrl,
-        }).subscribe(timelineStep => this.router.navigate(['/experiments', experimentId, 'timeline', timelineStep.sequence.toString()]));
+        }).subscribe(timelineStep => this.router.navigate(['/experiments', experimentId, 'timeline', timelineStep.sequence.toString()], { queryParamsHandling: 'preserve' }));
     }
 }

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -9,27 +9,27 @@
             Info
         </a>
         <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'workspace']"
-            [queryParams]="{template: routeTemplateId}" routerLinkActive="active">
+            queryParamsHandling="merge" routerLinkActive="active">
             Workspace
         </a>
         <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'data']"
-            [queryParams]="{template: routeTemplateId}" routerLinkActive="active">
+        queryParamsHandling="merge" routerLinkActive="active">
             Data
         </a>
         <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'timeline']"
-            [queryParams]="{template: routeTemplateId}" routerLinkActive="active">
+        queryParamsHandling="merge" routerLinkActive="active">
             Timeline
         </a>
         <a class="navigation-link" mat-button
             [routerLink]="['/experiments', (experimentId|async), 'extra', tab.resourceKey?.uiTemplateTabId]"
-            [queryParams]="{template: routeTemplateId}" routerLinkActive="active"
+            queryParamsHandling="merge" routerLinkActive="active"
             *ngFor="let tab of experimentExtraTabs">
             {{tab.name}}
         </a>
     </ng-container>
     <ng-container *ngIf="(currentExperiment|async) == null">
         <a class="navigation-link" mat-button [routerLink]="['extra', tab.resourceKey?.uiTemplateTabId]"
-            [queryParams]="{template: routeTemplateId}" routerLinkActive="active" *ngFor="let tab of generalExtraTabs">
+            queryParamsHandling="merge" routerLinkActive="active" *ngFor="let tab of generalExtraTabs">
             {{tab.name}}
         </a>
     </ng-container>

--- a/src/app/components/preview-list/preview-list.component.html
+++ b/src/app/components/preview-list/preview-list.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngFor="let data of resolvedDataList; trackBy: trackByFn">
     <qhana-data-preview [data]="data">
-        <a [routerLink]="['/experiments', experimentId, 'data', data.name, {version: data.version}]">
+        <a [routerLink]="['/experiments', experimentId, 'data', data.name, {version: data.version}]" queryParamsHandling="merge">
             <h5>{{data.name}} (version {{data.version}})</h5>
         </a>
     </qhana-data-preview>

--- a/src/app/components/timeline-step-nav/timeline-step-nav.component.html
+++ b/src/app/components/timeline-step-nav/timeline-step-nav.component.html
@@ -1,10 +1,10 @@
 <nav mat-tab-nav-bar class="big-nav-tabs">
-    <a mat-tab-link [routerLink]="['/experiments', experimentId, 'timeline', timelineStep, 'overview']"
+    <a mat-tab-link [routerLink]="['/experiments', experimentId, 'timeline', timelineStep, 'overview']" queryParamsHandling="preserve"
         [active]="active === 'overview'">
         Overview
     </a>
     <a mat-tab-link *ngFor="let tab of tabs"
-        [routerLink]="['/experiments', experimentId, 'timeline', timelineStep, tab.tabId]"
+        [routerLink]="['/experiments', experimentId, 'timeline', timelineStep, tab.tabId]" queryParamsHandling="preserve"
         [active]="active === tab.tabId">
         {{tab.name}}
     </a>

--- a/src/app/components/timeline-step-nav/timeline-step-nav.component.html
+++ b/src/app/components/timeline-step-nav/timeline-step-nav.component.html
@@ -1,10 +1,10 @@
 <nav mat-tab-nav-bar class="big-nav-tabs">
-    <a mat-tab-link [routerLink]="['/experiments', experimentId, 'timeline', timelineStep, 'overview']" queryParamsHandling="preserve"
+    <a mat-tab-link [routerLink]="['/experiments', experimentId, 'timeline', timelineStep, 'overview']" queryParamsHandling="merge"
         [active]="active === 'overview'">
         Overview
     </a>
     <a mat-tab-link *ngFor="let tab of tabs"
-        [routerLink]="['/experiments', experimentId, 'timeline', timelineStep, tab.tabId]" queryParamsHandling="preserve"
+        [routerLink]="['/experiments', experimentId, 'timeline', timelineStep, tab.tabId]" queryParamsHandling="merge"
         [active]="active === tab.tabId">
         {{tab.name}}
     </a>

--- a/src/app/components/timeline-step/timeline-step.component.html
+++ b/src/app/components/timeline-step/timeline-step.component.html
@@ -2,7 +2,7 @@
     <div class="title">
         <h1 class="t-page-headline">Timeline Step {{stepId}}</h1>
         <a mat-icon-button aria-label="back to timeline step list"
-            [routerLink]="['/experiments', experimentId, 'timeline']">
+            [routerLink]="['/experiments', experimentId, 'timeline']" queryParamsHandling="preserve">
             <mat-icon>arrow_back</mat-icon>
         </a>
     </div>

--- a/src/app/components/timeline-step/timeline-step.component.html
+++ b/src/app/components/timeline-step/timeline-step.component.html
@@ -2,7 +2,7 @@
     <div class="title">
         <h1 class="t-page-headline">Timeline Step {{stepId}}</h1>
         <a mat-icon-button aria-label="back to timeline step list"
-            [routerLink]="['/experiments', experimentId, 'timeline']" queryParamsHandling="preserve">
+            [routerLink]="['/experiments', experimentId, 'timeline']" queryParamsHandling="merge">
             <mat-icon>arrow_back</mat-icon>
         </a>
     </div>


### PR DESCRIPTION
This change is intended to preserve the `template` and `plugin` URL parameters when navigating between the workspace, data, and timeline tabs. This is done by setting `queryParamsHandling`, which means all URL parameters are preserved (not only `template` and `plugin`). Navigating to the info tab doesn't preserve the parameters, since it allows to set the default tab. 

Fixes #55