### PR TITLE
fix(downloads): panel width

### DIFF
--- a/src/app/components/navbar/navbar.component.sass
+++ b/src/app/components/navbar/navbar.component.sass
@@ -55,6 +55,9 @@
     width: 20rem
     padding: 0.5em
 
+::ng-deep.mat-mdc-menu-panel.download
+    max-width: 100% !important
+
 .download-container
     width: 100%
     display: flex


### PR DESCRIPTION
The delete button of download items was hidden due to the `max-width` of the respective `mat-menu-panel`. This PR sets the `max-width` such that the delete button can be seen and the user doesn't have to scroll.

Before:

![grafik](https://github.com/UST-QuAntiL/qhana-ui/assets/33042539/f9b99c36-f6c2-4c2d-9c07-ac98a3e2d13a)

After:

![grafik](https://github.com/UST-QuAntiL/qhana-ui/assets/33042539/fc0c09ce-2ff1-43f1-b3dc-79b9b021ad85)
