### PR TITLE
fix(template tab): disallow empty tab names

### DIFF
--- a/src/app/components-small/template-details/template-details.component.html
+++ b/src/app/components-small/template-details/template-details.component.html
@@ -10,7 +10,8 @@
     </mat-form-field>
     <mat-form-field class="form-field">
         <mat-label>Name:</mat-label>
-        <input matInput formControlName="name" required>
+        <input matInput formControlName="name">
+        <mat-error *ngIf="templateForm.controls['name'].invalid">Invalid tab name!</mat-error>
     </mat-form-field>
     <mat-form-field class="form-field">
         <mat-label>Description:</mat-label>

--- a/src/app/components-small/template-details/template-details.component.ts
+++ b/src/app/components-small/template-details/template-details.component.ts
@@ -35,7 +35,7 @@ export class TemplateDetailsComponent implements OnInit {
     };
 
     templateForm: FormGroup = this.fb.group({
-        name: [this.initialValues.name, Validators.required],
+        name: [this.initialValues.name, [Validators.required, Validators.minLength(1)]],
         description: this.initialValues.description,
         sortKey: this.initialValues.sortKey,
         location: [this.initialValues.location, [Validators.required, isInSetValidator(Object.keys(TAB_GROUP_NAME_OVERRIDES))]]
@@ -59,6 +59,10 @@ export class TemplateDetailsComponent implements OnInit {
     async onSubmit() {
         let findString: string;
         let response: ApiResponse<TemplateApiObject | TemplateTabApiObject> | null;
+        if (this.templateForm.invalid) {
+            console.log("TemplateDetailsComponent: form invalid");
+            return;
+        }
         if (this.templateLink != null) {
             findString = "create";
             response = await this.registry.getByApiLink<TemplateApiObject>(this.templateLink);

--- a/src/app/components-small/template-details/template-details.component.ts
+++ b/src/app/components-small/template-details/template-details.component.ts
@@ -60,7 +60,6 @@ export class TemplateDetailsComponent implements OnInit {
         let findString: string;
         let response: ApiResponse<TemplateApiObject | TemplateTabApiObject> | null;
         if (this.templateForm.invalid) {
-            console.log("TemplateDetailsComponent: form invalid");
             return;
         }
         if (this.templateLink != null) {


### PR DESCRIPTION
This PR is meant to hinder users from creating template tabs with empty names (`""`). The qhana-plugin-registry still allows empty tab names.