### PR TITLE
UI template editor

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -25,6 +25,7 @@ import { ExperimentsPageComponent } from './components/experiments-page/experime
 import { PluginTabComponent } from './components/plugin-tab/plugin-tab.component';
 import { SettingsPageComponent } from './components/settings-page/settings-page.component';
 import { TimelineStepComponent } from './components/timeline-step/timeline-step.component';
+import { UiTemplatesPageComponent } from './components/ui-templates-page/ui-templates-page.component';
 
 const NUMBER_REGEX = /^[0-9]+$/;
 
@@ -118,6 +119,8 @@ const extraTabsMatcher: UrlMatcher = (segments: UrlSegment[], group, route): Url
 const routes: Routes = [
     { path: '', component: ExperimentsPageComponent },
     { path: 'settings', component: SettingsPageComponent },
+    { path: 'templates', component: UiTemplatesPageComponent },
+    { path: 'templates/:templateId', component: UiTemplatesPageComponent },
     { path: 'experiments', component: ExperimentsPageComponent },
     { path: 'experiments/:experimentId', redirectTo: "info" },
     { path: 'experiments/:experimentId/info', component: ExperimentComponent },

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -50,8 +50,6 @@ const extraTabsMatcher: UrlMatcher = (segments: UrlSegment[], group, route): Url
         }
     }
 
-    console.log(consumed, params)
-
     // match: ./extra[/:path]/:templateTabId
     if (segments[index]?.path !== "extra") {
         return null;
@@ -80,8 +78,6 @@ const extraTabsMatcher: UrlMatcher = (segments: UrlSegment[], group, route): Url
     }
     params.templateTabId = tabId;
 
-    console.log(consumed, params)
-
     // found full match?
     if (index === segments.length) {
         return {
@@ -101,8 +97,6 @@ const extraTabsMatcher: UrlMatcher = (segments: UrlSegment[], group, route): Url
         consumed.push(segments[index]);
         index += 1;
     }
-
-    console.log(consumed, params)
 
     // found full match?
     if (index === segments.length && pluginId != null) {

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -91,7 +91,7 @@ const extraTabsMatcher: UrlMatcher = (segments: UrlSegment[], group, route): Url
     }
 
     // match: ./plugin/:pluginId
-    if (segments[index]?.path !== "plugins") {
+    if (segments[index]?.path !== "plugins" && segments[index]?.path !== "plugin") {
         return null;
     }
     consumed.push(segments[index]);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -88,6 +88,7 @@ import { DeleteDialog } from './dialogs/delete-dialog/delete-dialog.dialog';
 import { ExportExperimentDialog } from './dialogs/export-experiment/export-experiment.dialog';
 import { MarkdownHelpDialog } from './dialogs/markdown-help/markdown-help.dialog';
 import { UiTemplateComponent } from "./components-small/ui-template/ui-template.component";
+import { UiTemplateTabListComponent } from './components-small/ui-template-tab-list/ui-template-tab-list.component';
 
 @NgModule({
     declarations: [
@@ -136,6 +137,7 @@ import { UiTemplateComponent } from "./components-small/ui-template/ui-template.
         ChooseTemplateDialog,
         UiTemplatesPageComponent,
         UiTemplateComponent,
+        UiTemplateTabListComponent,
     ],
     imports: [
         BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -78,6 +78,7 @@ import { TabGroupListComponent } from './components/tab-group-list/tab-group-lis
 import { TimelineStepNavComponent } from './components/timeline-step-nav/timeline-step-nav.component';
 import { TimelineStepComponent } from './components/timeline-step/timeline-step.component';
 import { TimelineSubstepsComponent } from './components/timeline-substeps/timeline-substeps.component';
+import { UiTemplatesPageComponent } from './components/ui-templates-page/ui-templates-page.component';
 import { ChangeUiTemplateDialog } from './dialogs/change-ui-template/change-ui-template.dialog';
 import { ChooseDataDialog } from './dialogs/choose-data/choose-data.dialog';
 import { ChoosePluginDialog } from './dialogs/choose-plugin/choose-plugin.dialog';
@@ -132,6 +133,7 @@ import { MarkdownHelpDialog } from './dialogs/markdown-help/markdown-help.dialog
         PluginFilterEditorComponent,
         TabGroupListComponent,
         ChooseTemplateDialog,
+        UiTemplatesPageComponent,
     ],
     imports: [
         BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -89,6 +89,8 @@ import { ExportExperimentDialog } from './dialogs/export-experiment/export-exper
 import { MarkdownHelpDialog } from './dialogs/markdown-help/markdown-help.dialog';
 import { UiTemplateComponent } from "./components-small/ui-template/ui-template.component";
 import { UiTemplateTabListComponent } from './components-small/ui-template-tab-list/ui-template-tab-list.component';
+import { UiTemplateTabComponent } from './components-small/ui-template-tab/ui-template-tab.component';
+import { PluginFilterViewComponent } from './components-small/plugin-filter-view/plugin-filter-view.component';
 
 @NgModule({
     declarations: [
@@ -138,6 +140,8 @@ import { UiTemplateTabListComponent } from './components-small/ui-template-tab-l
         UiTemplatesPageComponent,
         UiTemplateComponent,
         UiTemplateTabListComponent,
+        UiTemplateTabComponent,
+        PluginFilterViewComponent,
     ],
     imports: [
         BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -87,6 +87,7 @@ import { CreateExperimentDialog } from './dialogs/create-experiment/create-exper
 import { DeleteDialog } from './dialogs/delete-dialog/delete-dialog.dialog';
 import { ExportExperimentDialog } from './dialogs/export-experiment/export-experiment.dialog';
 import { MarkdownHelpDialog } from './dialogs/markdown-help/markdown-help.dialog';
+import { UiTemplateComponent } from "./components-small/ui-template/ui-template.component";
 
 @NgModule({
     declarations: [
@@ -134,6 +135,7 @@ import { MarkdownHelpDialog } from './dialogs/markdown-help/markdown-help.dialog
         TabGroupListComponent,
         ChooseTemplateDialog,
         UiTemplatesPageComponent,
+        UiTemplateComponent,
     ],
     imports: [
         BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -91,6 +91,8 @@ import { UiTemplateComponent } from "./components-small/ui-template/ui-template.
 import { UiTemplateTabListComponent } from './components-small/ui-template-tab-list/ui-template-tab-list.component';
 import { UiTemplateTabComponent } from './components-small/ui-template-tab/ui-template-tab.component';
 import { PluginFilterViewComponent } from './components-small/plugin-filter-view/plugin-filter-view.component';
+import { UiTemplateTabFormComponent } from './components-small/ui-template-tab-form/ui-template-tab-form.component';
+import { PluginFilterFormComponent } from './components-small/plugin-filter-form/plugin-filter-form.component';
 
 @NgModule({
     declarations: [
@@ -141,7 +143,9 @@ import { PluginFilterViewComponent } from './components-small/plugin-filter-view
         UiTemplateComponent,
         UiTemplateTabListComponent,
         UiTemplateTabComponent,
+        UiTemplateTabFormComponent,
         PluginFilterViewComponent,
+        PluginFilterFormComponent,
     ],
     imports: [
         BrowserModule,

--- a/src/app/components-small/plugin-filter-form/plugin-filter-form.component.html
+++ b/src/app/components-small/plugin-filter-form/plugin-filter-form.component.html
@@ -1,0 +1,90 @@
+@if (filterValue == null) {
+    <p>Flter Plugins by:</p>
+    <mat-button-toggle-group class="toggle-group" aria-label="Filter Type">
+        <mat-button-toggle (click)="setType('id')">Identifier</mat-button-toggle>
+        <mat-button-toggle (click)="setType('name')">Name</mat-button-toggle>
+        <mat-button-toggle (click)="setType('version')">Version</mat-button-toggle>
+        <mat-button-toggle (click)="setType('type')">Type</mat-button-toggle>
+        <mat-button-toggle (click)="setType('tag')">Tag</mat-button-toggle>
+    </mat-button-toggle-group>
+    @if(depth < 4) {
+        <p>Or combine multiple filters with:</p>
+        <mat-button-toggle-group class="toggle-group" aria-label="Filter combinator">
+            <mat-button-toggle (click)="setType('and')">AND (match all filters)</mat-button-toggle>
+            <mat-button-toggle (click)="setType('or')">OR (match any filter)</mat-button-toggle>
+        </mat-button-toggle-group>
+    }
+} @else {
+    <div class="filter-head">
+        <mat-slide-toggle [checked]="isNegated" (toggleChange)="isNegated = !isNegated; updateFilterObject()">Exclude plugins matching this filter</mat-slide-toggle>
+        <button mat-icon-button (click)="resetCurrentFilter(); updateFilterObject()"><mat-icon>clear</mat-icon></button>
+    </div>
+}
+@if (isNestedFilter) {
+    <mat-button-toggle-group class="toggle-group" [value]="nestedFilterCombinator" (valueChange)="changeFilterCombinator($event)" aria-label="Filter combinator" >
+        <mat-button-toggle [value]="'and'">AND (match all filters)</mat-button-toggle>
+        <mat-button-toggle [value]="'or'">OR (match any filter)</mat-button-toggle>
+    </mat-button-toggle-group>
+
+    <div class="nested-filter-container">
+        <div class="filter-combinator">
+            <div class="line"></div>
+            <div>{{nestedFilterCombinator.toUpperCase()}}</div>
+            <div class="line"></div>
+        </div>
+        <div class="child-filter-list">
+            @if (filterValue?.length === 0) {
+                <p class="warning">Must have at least one plugin filter!</p>
+            }
+            @for (f of filterValue; track $index) {
+                <div class="child-filter-container">
+                    <mat-card class="child-filter">
+                        <mat-card-content>
+                            <qhana-plugin-filter-form [depth]="depth + 1" [filterIn]="f" (filterOut)="childFiltersOutput[$index] = $event; updateFilterObject()" (valid)="childFiltersValid[$index] = $event"></qhana-plugin-filter-form>
+                        </mat-card-content>
+                    </mat-card>
+                    <button mat-flat-button class="child-filter-remove-button" (click)="deleteChild($index)"><div><mat-icon>delete</mat-icon></div></button>
+                </div>
+            }
+            <button mat-raised-button class="add-child-filter-button" (click)="addChildFilter()"><mat-icon>plus</mat-icon>Add new filter</button>
+        </div>
+    </div>
+}
+@if (!isNestedFilter && filterType != null) {
+    <div class="simple-filter">
+        <mat-form-field class="filter-type-select">
+            <mat-label>Filter By:</mat-label>
+            <mat-select [value]="filterType" (valueChange)="changeSimpleFilterType($event)">
+                <mat-option value="id">Identifier</mat-option>
+                <mat-option value="name">Name</mat-option>
+                <mat-option value="tag">Tag</mat-option>
+                <mat-option value="version">Version</mat-option>
+                <mat-option value="type">Type</mat-option>
+            </mat-select>
+        </mat-form-field>
+        <mat-form-field class="filter-value">
+            <mat-label>Match against:</mat-label>
+            <input matInput [ngModel]="filterValue" (ngModelChange)="filterValue = $event; updateFilterObject()" [attr.list]="filterType === 'type' ? 'plugin-types' : null">
+            <datalist *ngIf="filterType === 'type'" id="plugin-types">
+                <option value="processing"></option>
+                <option value="visualization"></option>
+                <option value="conversion"></option>
+                <option value="dataloader"></option>
+                <option value="interaction"></option>
+            </datalist>
+            <mat-hint *ngIf="filterType === 'version'">
+                Examples: ">= 0.1.0", "== 1.0.2", "< 2.0.0", ">= 1.0.0, < 2.0.0" , "!= 1.0.14"
+            </mat-hint>
+            <mat-hint *ngIf="filterType === 'type'">
+                Examples: "processing", "conversion", "dataloader", "visualization", "interaction"
+            </mat-hint>
+        </mat-form-field>
+        <button mat-raised-button class="filter-button" (click)="openPluginChooser()" *ngIf="filterType === 'name' || filterType === 'id'">
+            choose
+        </button>
+    </div>
+}
+@if (depth > 0 && (filterValue == null || filterValue === "")) {
+    <p class="warning">Filter may not be empty!</p>
+}
+

--- a/src/app/components-small/plugin-filter-form/plugin-filter-form.component.sass
+++ b/src/app/components-small/plugin-filter-form/plugin-filter-form.component.sass
@@ -1,0 +1,67 @@
+.toggle-group
+    height: 3em
+
+.filter-head
+    display: flex
+    align-items: center
+    justify-content: space-between
+    width: 100%
+    margin-block-end: 0.5rem
+
+.simple-filter
+    display: flex
+    align-items: start
+    gap: 0.5rem
+    width: 100%
+
+.filter-type-selec
+    width: 8rem
+
+.filter-value
+    width: unset
+    flex-grow: 1
+
+.filter-button
+    height: 3.5rem
+
+.nested-filter-container
+    display: flex
+    gap: 1rem
+    align-items: stretch
+    margin-block: 1rem
+
+.filter-combinator
+    display: flex
+    flex-direction: column
+    align-items: center
+    min-width: 2.1rem
+
+    .line
+        flex-grow: 1
+        width: 0px
+        border-inline-start: 1px solid var(--text-washed)
+
+.child-filter-list
+    display: flex
+    flex-direction: column
+    gap: 0.8rem
+    flex-grow: 1
+
+.child-filter-container
+    display: flex
+    align-items: stretch
+    gap: 0.5rem
+
+.child-filter
+    flex-grow: 1
+
+.child-filter-remove-button
+    height: unset
+    min-width: 2rem
+    padding: 0px
+    display: flex
+    flex-direction: column
+    align-items: center
+
+.warning
+    color: var(--accent-text)

--- a/src/app/components-small/plugin-filter-form/plugin-filter-form.component.ts
+++ b/src/app/components-small/plugin-filter-form/plugin-filter-form.component.ts
@@ -1,0 +1,242 @@
+import { Component, EventEmitter, Input, Output, SimpleChanges } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { ChoosePluginDialog } from 'src/app/dialogs/choose-plugin/choose-plugin.dialog';
+import { PluginApiObject } from 'src/app/services/qhana-api-data-types';
+
+@Component({
+    selector: 'qhana-plugin-filter-form',
+    templateUrl: './plugin-filter-form.component.html',
+    styleUrl: './plugin-filter-form.component.sass'
+})
+export class PluginFilterFormComponent {
+    @Input() filterIn: any;
+    @Input() depth: number = 0;
+    @Output() filterOut = new EventEmitter<any>();
+    @Output() valid = new EventEmitter<boolean>();
+
+    filterValue: string | Array<any> | null = null;
+    isNestedFilter: boolean = false;
+    nestedFilterCombinator: "and" | "or" = "or";
+    isNegated: boolean = false;
+    filterType: 'id' | 'name' | 'tag' | 'version' | 'type' | null = null;
+
+    childFiltersOutput: Array<any> = [];
+    childFiltersValid: Array<boolean> = [];
+
+    constructor(private dialog: MatDialog) { }
+
+    ngOnInit(): void { }
+
+    ngOnChanges(changes: SimpleChanges) {
+        if (changes.filterIn != null) {
+            this.setupFilter();
+        }
+    }
+
+    resetCurrentFilter() {
+        this.isNegated = false;
+        this.filterValue = null;
+        this.filterType = null;
+        this.isNestedFilter = false;
+        this.nestedFilterCombinator = "or";
+        this.childFiltersOutput = [];
+        this.childFiltersValid = [];
+    }
+
+    setupFilter() {
+        if (!this.filterIn) {
+            // null or empty
+            this.resetCurrentFilter();
+            this.updateFilterObject();
+            return;
+        }
+        let filter = this.filterIn
+        let filterKeys = Object.keys(filter);
+        if (filterKeys.length !== 1) {
+            this.resetCurrentFilter();
+            this.updateFilterObject();
+            return;
+        }
+
+        if (filterKeys[0] === "not") {
+            this.isNegated = true;
+            filter = filter.not;
+            filterKeys = Object.keys(filter);
+
+            if (filterKeys.length === 0) {
+                this.resetCurrentFilter();
+                // specifically keep negated flag if child filter is empty!
+                this.isNegated = true;
+                this.updateFilterObject();
+                return;
+            } else if (filterKeys.length > 1) {
+                this.resetCurrentFilter();
+                this.updateFilterObject();
+                return;
+            }
+        }
+
+        if (filterKeys[0] === "and") {
+            this.isNestedFilter = true;
+            this.nestedFilterCombinator = "and";
+            this.filterType = null;
+            this.childFiltersOutput = [...filter.and];
+            this.childFiltersValid = filter.and.map(() => true);
+            this.filterValue = filter.and;
+            this.updateFilterObject();
+            return;
+        }
+
+        if (filterKeys[0] === "or") {
+            this.isNestedFilter = true;
+            this.nestedFilterCombinator = "or";
+            this.filterType = null;
+            this.childFiltersOutput = [...filter.or];
+            this.childFiltersValid = filter.or.map(() => true);
+            this.filterValue = filter.or;
+            this.updateFilterObject();
+            return;
+        }
+
+        if (['id', 'name', 'tag', 'version', 'type'].some(t => t === filterKeys[0])) {
+            this.isNestedFilter = false;
+            this.nestedFilterCombinator = "or";
+            this.childFiltersOutput = [];
+            this.childFiltersValid = [];
+            this.filterType = filterKeys[0] as any;
+            this.filterValue = filter[filterKeys[0]];
+            this.updateFilterObject();
+            return;
+        }
+
+        this.resetCurrentFilter();
+        this.updateFilterObject();
+        return;
+    }
+
+    updateFilterObject() {
+        let filter: any = {};
+        if (this.isNestedFilter) {
+            filter[this.nestedFilterCombinator] = this.childFiltersOutput.filter(v => Boolean(v));
+        } else if (this.filterType != null) {
+            filter[this.filterType] = this.filterValue;
+        }
+
+        let isValid = true;
+        if (this.isNestedFilter) {
+            if (this.childFiltersOutput.length === 0) {
+                isValid = false;  // nested filters must have at least one child filter
+            }
+            if (this.childFiltersValid.some(valid => !valid)) {
+                isValid = false;  // nested filters cannot have invalid child filters
+            }
+        } else if (this.depth > 0) {
+            if (this.filterType == null) {
+                isValid = false;  // nested filters cannot be empty
+            }
+            if (this.filterValue == null || this.filterValue === "") {
+                isValid = false;  // nested filters cannot be empty
+            }
+        }
+
+        if (this.isNegated) {
+            filter = { not: filter };
+        }
+
+        if (this.childFiltersOutput === this.filterValue) {
+            console.warn("Possible infinite update loop, aborting update!");
+            return
+        }
+        Promise.resolve().then(() => {
+            this.valid.emit(isValid);
+            this.filterOut.emit(filter);
+        });
+    }
+
+    deleteChild(index: number) {
+        if (!this.isNestedFilter || !Array.isArray(this.filterValue)) {
+            return;
+        }
+        if (this.childFiltersOutput.length >= index + 1) {
+            const newFilterValue = [...this.childFiltersOutput]
+            newFilterValue.splice(index, 1);
+            this.childFiltersOutput = newFilterValue
+            this.childFiltersValid.splice(index, 1);
+            this.filterValue = [...newFilterValue];
+            this.updateFilterObject();
+        }
+    }
+
+    addChildFilter() {
+        if (!this.isNestedFilter || !Array.isArray(this.filterValue)) {
+            return;
+        }
+        const filter: any = {};
+        this.childFiltersOutput.push(filter);
+        this.childFiltersValid.push(true);
+        this.filterValue.push(filter);
+        this.updateFilterObject();
+    }
+
+    setType(type: 'and' | 'or' | 'id' | 'name' | 'tag' | 'version' | 'type') {
+        if (this.isNestedFilter || this.filterType != null) {
+            return; // already chose a filter type
+        }
+        if (type === "and" || type === "or") {
+            this.isNestedFilter = true;
+            this.nestedFilterCombinator = type;
+            this.filterType = null;
+            // start with one empty filter
+            this.childFiltersOutput = [null];
+            this.childFiltersValid = [true];
+            this.filterValue = [null];
+            this.updateFilterObject();
+            return;
+        }
+
+        this.isNestedFilter = false;
+        this.nestedFilterCombinator = "or";
+        this.filterType = type;
+        this.childFiltersOutput = [];
+        this.childFiltersValid = []
+        this.filterValue = "";
+        this.updateFilterObject();
+    }
+
+    changeFilterCombinator(combinator: "and" | "or") {
+        if (!this.isNestedFilter || this.nestedFilterCombinator === combinator) {
+            return;
+        }
+        this.nestedFilterCombinator = combinator;
+        this.updateFilterObject();
+    }
+
+    changeSimpleFilterType(type: 'id' | 'name' | 'tag' | 'version' | 'type') {
+        if (this.isNestedFilter || this.filterType === type) {
+            return;
+        }
+        this.filterType = type;
+        this.updateFilterObject();
+    }
+
+    openPluginChooser() {
+        const dialogRef = this.dialog.open(ChoosePluginDialog, {});
+        dialogRef.afterClosed().subscribe((result: PluginApiObject | null) => {
+            if (result == null) {
+                return; // nothing was selected
+            }
+            if (this.isNestedFilter) {
+                return;
+            }
+            if (this.filterType === "id") {
+                this.filterValue = result.identifier;
+                this.updateFilterObject();
+            }
+            if (this.filterType === "name") {
+                this.filterValue = result.title;
+                this.updateFilterObject();
+            }
+        });
+    }
+
+}

--- a/src/app/components-small/plugin-filter-view/plugin-filter-view.component.html
+++ b/src/app/components-small/plugin-filter-view/plugin-filter-view.component.html
@@ -5,7 +5,7 @@
             <div>AND</div>
             <div class="line"></div>
         </div>
-        <div>
+        <div class="child-filters">
             @for (f of filter.and; track $index) {
                 <qhana-plugin-filter-view [filter]="f"></qhana-plugin-filter-view>
             }
@@ -19,7 +19,7 @@
             <div>OR</div>
             <div class="line"></div>
         </div>
-        <div>
+        <div class="child-filters">
             @for (f of filter.or; track $index) {
                 <qhana-plugin-filter-view [filter]="f"></qhana-plugin-filter-view>
             }

--- a/src/app/components-small/plugin-filter-view/plugin-filter-view.component.html
+++ b/src/app/components-small/plugin-filter-view/plugin-filter-view.component.html
@@ -1,0 +1,53 @@
+@if (filterType === "and") {
+    <div class="filter-container">
+        <div class="filter-type">
+            <div class="line"></div>
+            <div>AND</div>
+            <div class="line"></div>
+        </div>
+        <div>
+            @for (f of filter.and; track $index) {
+                <qhana-plugin-filter-view [filter]="f"></qhana-plugin-filter-view>
+            }
+        </div>
+    </div>
+}
+@if (filterType === "or") {
+    <div class="filter-container">
+        <div class="filter-type">
+            <div class="line"></div>
+            <div>OR</div>
+            <div class="line"></div>
+        </div>
+        <div>
+            @for (f of filter.or; track $index) {
+                <qhana-plugin-filter-view [filter]="f"></qhana-plugin-filter-view>
+            }
+        </div>
+    </div>
+}
+@if (filterType === "not") {
+    <div class="single-filter-container">
+        <p>NOT</p>
+        <div class="line"></div>
+        <qhana-plugin-filter-view [filter]="filter.not"></qhana-plugin-filter-view>
+    </div>
+}
+@if (filterType === "id") {
+    <p>Plugin ID: {{filter.id}}</p>
+}
+@if (filterType === "name") {
+    <p>Plugin name: {{filter.name}}</p>
+}
+@if (filterType === "version") {
+    <p>Plugin version: {{filter.version}}</p>
+}
+@if (filterType === "tag") {
+    <p>Plugin tag: {{filter.tag}}</p>
+}
+@if (filterType === "type") {
+    <p>Plugin type: {{filter.type}}</p>
+}
+@if (filterType === "empty") {
+    <p>No filter set.</p>
+}

--- a/src/app/components-small/plugin-filter-view/plugin-filter-view.component.sass
+++ b/src/app/components-small/plugin-filter-view/plugin-filter-view.component.sass
@@ -13,6 +13,11 @@
         width: 0px
         border-inline-start: 1px solid var(--text-washed)
 
+.child-filters
+    display: flex
+    flex-direction: column
+    gap: 0.5rem
+
 .single-filter-container
     display: flex
     gap: 0.5rem

--- a/src/app/components-small/plugin-filter-view/plugin-filter-view.component.sass
+++ b/src/app/components-small/plugin-filter-view/plugin-filter-view.component.sass
@@ -1,0 +1,24 @@
+.filter-container
+    display: flex
+    gap: 1rem
+    align-items: stretch
+
+.filter-type
+    display: flex
+    flex-direction: column
+    align-items: center
+
+    .line
+        flex-grow: 1
+        width: 0px
+        border-inline-start: 1px solid var(--text-washed)
+
+.single-filter-container
+    display: flex
+    gap: 0.5rem
+    align-items: center
+
+    .line
+        align-self: stretch
+        width: 0px
+        border-inline-start: 1px solid var(--text-washed)

--- a/src/app/components-small/plugin-filter-view/plugin-filter-view.component.ts
+++ b/src/app/components-small/plugin-filter-view/plugin-filter-view.component.ts
@@ -1,0 +1,43 @@
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+const ALLOWED_FILTER_KEYS: Set<'and' | 'or' | 'not' | 'id' | 'name' | 'tag' | 'version' | 'type'> = new Set(['and', 'or', 'not', 'id', 'name', 'tag', 'version', 'type']);
+
+function isAllowedFilter(filterType: string): filterType is 'and' | 'or' | 'not' | 'id' | 'name' | 'tag' | 'version' | 'type' {
+    return ALLOWED_FILTER_KEYS.has(filterType as any);
+}
+
+@Component({
+    selector: 'qhana-plugin-filter-view',
+    templateUrl: './plugin-filter-view.component.html',
+    styleUrl: './plugin-filter-view.component.sass'
+})
+export class PluginFilterViewComponent implements OnChanges {
+
+    @Input() filter: any = null;
+
+    filterType: 'empty' | 'and' | 'or' | 'not' | 'id' | 'name' | 'tag' | 'version' | 'type' | null = null;
+
+    ngOnChanges(changes: SimpleChanges): void {
+        if (this.filter == null) {
+            this.filterType = null;
+            return;
+        }
+
+        const keys = Object.keys(this.filter);
+        if (keys.length !== 1) {
+            if (keys.length === 0) {
+                this.filterType = 'empty';
+            } else {
+                this.filterType = null;
+            }
+            return;
+        }
+        const filterType = keys[0];
+        if (!isAllowedFilter(filterType)) {
+            this.filterType = null;
+            return;
+        }
+        this.filterType = filterType;
+    }
+}

--- a/src/app/components-small/ui-template-tab-form/ui-template-tab-form.component.html
+++ b/src/app/components-small/ui-template-tab-form/ui-template-tab-form.component.html
@@ -1,0 +1,43 @@
+<form [formGroup]="templateForm" (ngSubmit)="onSubmit()" *ngIf="templateForm">
+    <mat-form-field class="form-field">
+        <mat-label>Name:</mat-label>
+        <input matInput formControlName="name">
+        <mat-error *ngIf="templateForm.controls['name'].invalid">Invalid tab name!</mat-error>
+    </mat-form-field>
+    <div>
+        <p>Description:</p>
+        <qhana-markdown class="qhana-form-input" style="display: block; border-width: 1px;" [markdown]="tabData?.description ?? ''" [editable]="true" (markdownChanges)="description = $event; updateDirty()"></qhana-markdown>
+    </div>
+    <div class="location-chooser">
+        <p style="margin-bottom: 0;">Show tab in:</p>
+        <mat-radio-group aria-label="Select the location of the template tab" formControlName="location"
+            [required]="true">
+            <mat-radio-button [value]="location.key" *ngFor="let location of tabGroupNameOverrides">
+                {{location.value}}
+            </mat-radio-button>
+        </mat-radio-group>
+    </div>
+    <mat-form-field class="form-field" [hidden]="!templateForm.value.location || templateForm.value.location === 'workspace'">
+        <mat-label>Tab Group:</mat-label>
+        <input matInput formControlName="locationExtra">
+        <mat-hint>The group key of the tab this tab should be grouped under. (Use '.' to separate group keys for nested groups.)</mat-hint>
+    </mat-form-field>
+    <mat-form-field class="form-field">
+        <mat-label>Sort Key:</mat-label>
+        <input matInput type="number" formControlName="sortKey">
+    </mat-form-field>
+    <div class="icon-field-wrapper">
+        <mat-form-field class="form-field">
+            <mat-label>Icon:</mat-label>
+            <input matInput formControlName="icon">
+        </mat-form-field>
+        <mat-icon class="icon-preview">{{templateForm.value.icon || "extension"}}</mat-icon>
+    </div>
+    <mat-form-field class="form-field">
+        <mat-label>Group Key:</mat-label>
+        <input matInput pattern="[^\.]*" formControlName="groupKey">
+        <mat-hint>Establish this tab as its own tab group. (Cannot contain '.')</mat-hint>
+    </mat-form-field>
+    <p class="form-error" *ngIf="templateForm?.errors?.groupKeyForbidden">Group key cannot be used in experiment workspace tabs!</p>
+    <qhana-plugin-filter-form [filterIn]="currentPluginFilter" (filterOut)="updatedPluginFilter = $event; updateDirty()" (valid)="pluginFilterValid = $event; updateValid()"></qhana-plugin-filter-form>
+</form>

--- a/src/app/components-small/ui-template-tab-form/ui-template-tab-form.component.sass
+++ b/src/app/components-small/ui-template-tab-form/ui-template-tab-form.component.sass
@@ -1,0 +1,25 @@
+.form-field
+    width: 100%
+    margin-block-end: 0.5rem
+
+.filter-example
+    resize: none
+    overflow: hidden
+
+.location-chooser
+    margin-block-end: 1rem
+
+.icon-field-wrapper
+    display: flex
+    gap: 1rem
+    align-items: baseline
+
+.icon-preview
+    font-size: 24px
+    margin-inline: 1rem
+
+.submit-button
+    margin-block-start: 2rem
+
+.form-error
+    color: var(--warn-text)

--- a/src/app/components-small/ui-template-tab-form/ui-template-tab-form.component.ts
+++ b/src/app/components-small/ui-template-tab-form/ui-template-tab-form.component.ts
@@ -1,0 +1,186 @@
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
+import { TAB_GROUP_NAME_OVERRIDES, TemplateTabApiObject } from 'src/app/services/templates.service';
+import { FormBuilder, FormGroup, ValidationErrors, Validators, ValidatorFn, AbstractControl } from '@angular/forms';
+import { Subscription } from 'rxjs';
+
+export function isInSetValidator(validValues: any[]): ValidatorFn {
+    return (control: AbstractControl): { [key: string]: any } | null => {
+        if (!validValues.includes(control.value)) {
+            return { invalidValue: true };
+        }
+        return null;
+    };
+}
+
+@Component({
+    selector: 'qhana-ui-template-tab-form',
+    templateUrl: './ui-template-tab-form.component.html',
+    styleUrl: './ui-template-tab-form.component.sass'
+})
+export class UiTemplateTabFormComponent implements OnChanges, OnDestroy, OnInit {
+
+    @Input() tabData: TemplateTabApiObject | null = null;
+
+    @Output() isDirty: EventEmitter<boolean> = new EventEmitter(false);
+    @Output() isValid: EventEmitter<boolean> = new EventEmitter(false);
+    @Output() data: EventEmitter<any> = new EventEmitter();
+    @Output() formSubmit: EventEmitter<void> = new EventEmitter();
+
+    private formStatusSubscription: Subscription | null = null;
+    private formValueSubscription: Subscription | null = null;
+
+    description: string = "";
+
+    currentPluginFilter: any = null;
+
+    updatedPluginFilter: any = null;
+    pluginFilterValid: boolean = false;
+
+    tabGroupNameOverrides = Object.entries(TAB_GROUP_NAME_OVERRIDES)
+        .map(entry => { return { key: entry[0], value: entry[1] }; })
+        .sort((a, b) => {
+            if (a.key === "workspace") {
+                return -1;
+            }
+            else if (b.key === "workspace") {
+                return 1;
+            }
+            return a.value.localeCompare(b.value)
+        });
+
+    private initialValues = {
+        name: "",
+        icon: null,
+        sortKey: 0,
+        location: "workspace",
+        locationExtra: "",
+        groupKey: "",
+    };
+
+    templateForm: FormGroup | null = null;
+
+    constructor(private fb: FormBuilder) { }
+
+    ngOnInit(): void {
+        this.ngOnChanges({});
+    }
+
+    ngOnDestroy(): void {
+        this.formStatusSubscription?.unsubscribe();
+        this.formValueSubscription?.unsubscribe();
+    }
+
+    ngOnChanges(changes: SimpleChanges): void {
+        this.formStatusSubscription?.unsubscribe();
+        this.formValueSubscription?.unsubscribe();
+        const templateForm = this.fb.group({
+            name: [this.initialValues.name, [Validators.required, Validators.minLength(1)]],
+            icon: [this.initialValues.locationExtra, [Validators.maxLength(64)]],
+            sortKey: this.initialValues.sortKey,
+            location: [this.initialValues.location, [Validators.required, isInSetValidator(Object.keys(TAB_GROUP_NAME_OVERRIDES))]],
+            locationExtra: [this.initialValues.locationExtra],
+            groupKey: [this.initialValues.locationExtra, [Validators.maxLength(32)]],
+        });
+        templateForm.addValidators((control): ValidationErrors | null => {
+            const loc = control.get("location")?.getRawValue() ?? "";
+            if (loc === "workspace") {
+                const groupKey = control.get("groupKey")?.getRawValue() ?? "";
+                if (groupKey) {
+                    return {
+                        groupKeyForbidden: true,
+                    };
+                }
+            }
+            return null;
+        });
+        if (this.tabData != null) {
+            const location = this.tabData.location;
+            const [baseLocation, locationExtra] = location.split(".", 2);
+            this.description = this.tabData.description;
+            try {
+                this.currentPluginFilter = JSON.parse(this.tabData.filterString);
+            } catch {
+                this.currentPluginFilter = null;
+            }
+            templateForm.setValue({
+                name: this.tabData.name,
+                icon: this.tabData.icon,
+                sortKey: this.tabData.sortKey,
+                groupKey: this.tabData.groupKey,
+                location: baseLocation,
+                locationExtra: locationExtra ?? "",
+            });
+        } else {
+            this.description = "";
+        }
+        this.formStatusSubscription = templateForm.statusChanges.subscribe(() => {
+            this.updateDirty();
+            this.isValid.emit(!templateForm.invalid);
+        });
+        this.formValueSubscription = templateForm.valueChanges.subscribe((value) => {
+            let location = value.location ?? "workspace";
+            if (value.locationExtra) {
+                location = `${location}.${value.locationExtra}`;
+            }
+            const data: any = {
+                "name": value.name,
+                "icon": value.icon,
+                "sortKey": value.sortKey,
+                "location": location,
+                "groupKey": value.groupKey ?? "",
+            };
+            data.description = this.description;
+            if (value.groupKey) {
+                data.filterString = ""
+            } else {
+                if (this.updatedPluginFilter) {
+                    data.filterString = JSON.stringify(this.updatedPluginFilter);
+                } else {
+                    data.filterString = "{}";
+                }
+            }
+            this.data.emit(data);
+        });
+        this.templateForm = templateForm;
+    }
+
+    public submitForm() {
+        this.templateForm?.updateValueAndValidity();
+        this.formSubmit.emit();
+    }
+
+    async onSubmit() {
+        this.formSubmit.emit();
+    }
+
+    updateDirty() {
+        let dirty = (this.templateForm?.dirty ?? false) || (this.description !== this.tabData?.description ?? "");
+
+        if (Boolean(this.currentPluginFilter) && Boolean(this.updatedPluginFilter)) {
+            if (JSON.stringify(this.currentPluginFilter) !== JSON.stringify(this.updatedPluginFilter)) {
+                dirty = true;
+            }
+        } else if (Boolean(this.currentPluginFilter) !== Boolean(this.updatedPluginFilter)) {
+            dirty = true;
+        }
+
+        Promise.resolve().then(() => {
+            this.isDirty.emit(dirty);
+        });
+    }
+
+    updateValid() {
+        let isValid = true;
+        if (this.templateForm == null || this.templateForm.invalid) {
+            isValid = false;
+        }
+        if (!this.pluginFilterValid) {
+            isValid = false;
+        }
+
+        Promise.resolve().then(() => {
+            this.isValid.emit(isValid);
+        });
+    }
+
+}

--- a/src/app/components-small/ui-template-tab-list/ui-template-tab-list.component.html
+++ b/src/app/components-small/ui-template-tab-list/ui-template-tab-list.component.html
@@ -1,4 +1,12 @@
-<div *ngIf="navigationGroups.length > 0 || navigationGroup != null">
+<mat-expansion-panel *ngIf="createTabLink != null">
+    <mat-expansion-panel-header>
+        <mat-panel-title class="tab-title">Create New Tab</mat-panel-title>
+    </mat-expansion-panel-header>
+    <qhana-ui-template-tab-form  (isValid)="isValid = $event" (data)="newTabData = $event" (formSubmit)="createNewTab()" #newTabForm></qhana-ui-template-tab-form>
+    <button class="new-tab-button" mat-flat-button color="primary" [disabled]="!isValid" (click)="newTabForm.submitForm()"><mat-icon>save</mat-icon>save</button>
+</mat-expansion-panel>
+
+<div *ngIf="!isLoading && (navigationGroups.length > 0 || navigationGroup != null)">
     <h3>Navigation Tab Groups</h3>
     <mat-accordion *ngIf="navigationGroup != null">
         @for (tab of navigationGroup.tabs; track tab.href) {
@@ -11,7 +19,7 @@
                     </mat-panel-title>
                     <mat-panel-description *ngIf="hrefToTab.get(tab.href)?.groupKey">(Group: {{navigationGroup.groupKey}}.{{hrefToTab.get(tab.href)?.groupKey}})</mat-panel-description>
                 </mat-expansion-panel-header>
-                <qhana-ui-template-tab [tabLink]="tab"></qhana-ui-template-tab>
+                <qhana-ui-template-tab [tabLink]="tab" [useCache]="true"></qhana-ui-template-tab>
             </mat-expansion-panel>
         }
     </mat-accordion>
@@ -33,17 +41,13 @@
                         </mat-panel-title>
                         <mat-panel-description *ngIf="hrefToTab.get(tab.href)?.groupKey">(Group: {{group.groupKey}}.{{hrefToTab.get(tab.href)?.groupKey}})</mat-panel-description>
                     </mat-expansion-panel-header>
-                    <qhana-ui-template-tab [tabLink]="tab"></qhana-ui-template-tab>
+                    <qhana-ui-template-tab [tabLink]="tab" [useCache]="true"></qhana-ui-template-tab>
                 </mat-expansion-panel>
             }
         </mat-accordion>
     }
-    <ul>
-        <li *ngIf="navigationGroup != null">{{navigationGroup.name}}</li>
-        <li *ngFor="let group of navigationGroups">{{group.name}} - {{group.groupKey}}</li>
-    </ul>
 </div>
-<div *ngIf="workspaceGroup != null">
+<div *ngIf="!isLoading && workspaceGroup != null">
     <h3>Experiment Workspace Tabs</h3>
     <mat-accordion>
         @for (tab of workspaceGroup.tabs; track tab.href) {
@@ -54,12 +58,12 @@
                         {{tab.name}}
                     </mat-panel-title>
                 </mat-expansion-panel-header>
-                <qhana-ui-template-tab [tabLink]="tab"></qhana-ui-template-tab>
+                <qhana-ui-template-tab [tabLink]="tab" [useCache]="true"></qhana-ui-template-tab>
             </mat-expansion-panel>
         }
     </mat-accordion>
 </div>
-<div *ngIf="experimentNavigationGroups.length > 0 || experimentNavigationGroup != null">
+<div *ngIf="!isLoading && (experimentNavigationGroups.length > 0 || experimentNavigationGroup != null)">
     <h3>Experiment Navigation Tab Groups</h3>
     <mat-accordion *ngIf="experimentNavigationGroup != null">
         @for (tab of experimentNavigationGroup.tabs; track tab.href) {
@@ -72,7 +76,7 @@
                     </mat-panel-title>
                     <mat-panel-description *ngIf="hrefToTab.get(tab.href)?.groupKey">(Group: {{experimentNavigationGroup.groupKey}}.{{hrefToTab.get(tab.href)?.groupKey}})</mat-panel-description>
                 </mat-expansion-panel-header>
-                <qhana-ui-template-tab [tabLink]="tab"></qhana-ui-template-tab>
+                <qhana-ui-template-tab [tabLink]="tab" [useCache]="true"></qhana-ui-template-tab>
             </mat-expansion-panel>
         }
     </mat-accordion>
@@ -94,13 +98,13 @@
                         </mat-panel-title>
                         <mat-panel-description *ngIf="hrefToTab.get(tab.href)?.groupKey">(Group: {{group.groupKey}}.{{hrefToTab.get(tab.href)?.groupKey}})</mat-panel-description>
                     </mat-expansion-panel-header>
-                    <qhana-ui-template-tab [tabLink]="tab"></qhana-ui-template-tab>
+                    <qhana-ui-template-tab [tabLink]="tab" [useCache]="true"></qhana-ui-template-tab>
                 </mat-expansion-panel>
             }
         </mat-accordion>
     }
 </div>
-<div *ngIf="unknownGroups.length > 0">
+<div *ngIf="!isLoading && unknownGroups.length > 0">
     <h3>Unknown Tab Groups</h3>
     @for (group of unknownGroups; track group.groupKey) {
         <h4>
@@ -119,7 +123,7 @@
                         </mat-panel-title>
                         <mat-panel-description *ngIf="hrefToTab.get(tab.href)?.groupKey">(Group: {{group.groupKey}}.{{hrefToTab.get(tab.href)?.groupKey}})</mat-panel-description>
                     </mat-expansion-panel-header>
-                    <qhana-ui-template-tab [tabLink]="tab"></qhana-ui-template-tab>
+                    <qhana-ui-template-tab [tabLink]="tab" [useCache]="true"></qhana-ui-template-tab>
                 </mat-expansion-panel>
             }
         </mat-accordion>

--- a/src/app/components-small/ui-template-tab-list/ui-template-tab-list.component.html
+++ b/src/app/components-small/ui-template-tab-list/ui-template-tab-list.component.html
@@ -11,7 +11,7 @@
                     </mat-panel-title>
                     <mat-panel-description *ngIf="hrefToTab.get(tab.href)?.groupKey">(Group: {{navigationGroup.groupKey}}.{{hrefToTab.get(tab.href)?.groupKey}})</mat-panel-description>
                 </mat-expansion-panel-header>
-                <p>TODO: CONTENT</p>
+                <qhana-ui-template-tab [tabLink]="tab"></qhana-ui-template-tab>
             </mat-expansion-panel>
         }
     </mat-accordion>
@@ -33,7 +33,7 @@
                         </mat-panel-title>
                         <mat-panel-description *ngIf="hrefToTab.get(tab.href)?.groupKey">(Group: {{group.groupKey}}.{{hrefToTab.get(tab.href)?.groupKey}})</mat-panel-description>
                     </mat-expansion-panel-header>
-                    <p>TODO: CONTENT</p>
+                    <qhana-ui-template-tab [tabLink]="tab"></qhana-ui-template-tab>
                 </mat-expansion-panel>
             }
         </mat-accordion>
@@ -54,7 +54,7 @@
                         {{tab.name}}
                     </mat-panel-title>
                 </mat-expansion-panel-header>
-                <p>TODO: CONTENT</p>
+                <qhana-ui-template-tab [tabLink]="tab"></qhana-ui-template-tab>
             </mat-expansion-panel>
         }
     </mat-accordion>
@@ -72,7 +72,7 @@
                     </mat-panel-title>
                     <mat-panel-description *ngIf="hrefToTab.get(tab.href)?.groupKey">(Group: {{experimentNavigationGroup.groupKey}}.{{hrefToTab.get(tab.href)?.groupKey}})</mat-panel-description>
                 </mat-expansion-panel-header>
-                <p>TODO: CONTENT</p>
+                <qhana-ui-template-tab [tabLink]="tab"></qhana-ui-template-tab>
             </mat-expansion-panel>
         }
     </mat-accordion>
@@ -94,7 +94,7 @@
                         </mat-panel-title>
                         <mat-panel-description *ngIf="hrefToTab.get(tab.href)?.groupKey">(Group: {{group.groupKey}}.{{hrefToTab.get(tab.href)?.groupKey}})</mat-panel-description>
                     </mat-expansion-panel-header>
-                    <p>TODO: CONTENT</p>
+                    <qhana-ui-template-tab [tabLink]="tab"></qhana-ui-template-tab>
                 </mat-expansion-panel>
             }
         </mat-accordion>
@@ -119,7 +119,7 @@
                         </mat-panel-title>
                         <mat-panel-description *ngIf="hrefToTab.get(tab.href)?.groupKey">(Group: {{group.groupKey}}.{{hrefToTab.get(tab.href)?.groupKey}})</mat-panel-description>
                     </mat-expansion-panel-header>
-                    <p>TODO: CONTENT</p>
+                    <qhana-ui-template-tab [tabLink]="tab"></qhana-ui-template-tab>
                 </mat-expansion-panel>
             }
         </mat-accordion>

--- a/src/app/components-small/ui-template-tab-list/ui-template-tab-list.component.html
+++ b/src/app/components-small/ui-template-tab-list/ui-template-tab-list.component.html
@@ -1,0 +1,127 @@
+<div *ngIf="navigationGroups.length > 0 || navigationGroup != null">
+    <h3>Navigation Tab Groups</h3>
+    <mat-accordion *ngIf="navigationGroup != null">
+        @for (tab of navigationGroup.tabs; track tab.href) {
+            <mat-expansion-panel>
+                <mat-expansion-panel-header>
+                    <mat-panel-title class="tab-title">
+                        <mat-icon *ngIf="hrefToTab.get(tab.href)?.icon">{{hrefToTab.get(tab.href)?.icon}}</mat-icon>
+                        {{tab.name}}
+                        <mat-icon *ngIf="hrefToTab.get(tab.href)?.groupKey">more_vert</mat-icon>
+                    </mat-panel-title>
+                    <mat-panel-description *ngIf="hrefToTab.get(tab.href)?.groupKey">(Group: {{navigationGroup.groupKey}}.{{hrefToTab.get(tab.href)?.groupKey}})</mat-panel-description>
+                </mat-expansion-panel-header>
+                <p>TODO: CONTENT</p>
+            </mat-expansion-panel>
+        }
+    </mat-accordion>
+
+    @for (group of navigationGroups; track group.groupKey) {
+        <h4>
+            <mat-icon *ngIf="group.icon">{{group.icon}}</mat-icon>
+            {{group.name}}
+            <span class="group-title-extra">(Group: {{group.groupKey}})</span>
+        </h4>
+        <mat-accordion>
+            @for (tab of group.tabs; track tab.href) {
+                <mat-expansion-panel>
+                    <mat-expansion-panel-header>
+                        <mat-panel-title class="tab-title">
+                            <mat-icon *ngIf="hrefToTab.get(tab.href)?.icon">{{hrefToTab.get(tab.href)?.icon}}</mat-icon>
+                            {{tab.name}}
+                            <mat-icon *ngIf="hrefToTab.get(tab.href)?.groupKey">more_vert</mat-icon>
+                        </mat-panel-title>
+                        <mat-panel-description *ngIf="hrefToTab.get(tab.href)?.groupKey">(Group: {{group.groupKey}}.{{hrefToTab.get(tab.href)?.groupKey}})</mat-panel-description>
+                    </mat-expansion-panel-header>
+                    <p>TODO: CONTENT</p>
+                </mat-expansion-panel>
+            }
+        </mat-accordion>
+    }
+    <ul>
+        <li *ngIf="navigationGroup != null">{{navigationGroup.name}}</li>
+        <li *ngFor="let group of navigationGroups">{{group.name}} - {{group.groupKey}}</li>
+    </ul>
+</div>
+<div *ngIf="workspaceGroup != null">
+    <h3>Experiment Workspace Tabs</h3>
+    <mat-accordion>
+        @for (tab of workspaceGroup.tabs; track tab.href) {
+            <mat-expansion-panel>
+                <mat-expansion-panel-header>
+                    <mat-panel-title class="tab-title">
+                        <mat-icon *ngIf="hrefToTab.get(tab.href)?.icon">{{hrefToTab.get(tab.href)?.icon}}</mat-icon>
+                        {{tab.name}}
+                    </mat-panel-title>
+                </mat-expansion-panel-header>
+                <p>TODO: CONTENT</p>
+            </mat-expansion-panel>
+        }
+    </mat-accordion>
+</div>
+<div *ngIf="experimentNavigationGroups.length > 0 || experimentNavigationGroup != null">
+    <h3>Experiment Navigation Tab Groups</h3>
+    <mat-accordion *ngIf="experimentNavigationGroup != null">
+        @for (tab of experimentNavigationGroup.tabs; track tab.href) {
+            <mat-expansion-panel>
+                <mat-expansion-panel-header>
+                    <mat-panel-title class="tab-title">
+                        <mat-icon *ngIf="hrefToTab.get(tab.href)?.icon">{{hrefToTab.get(tab.href)?.icon}}</mat-icon>
+                        {{tab.name}}
+                        <mat-icon *ngIf="hrefToTab.get(tab.href)?.groupKey">more_vert</mat-icon>
+                    </mat-panel-title>
+                    <mat-panel-description *ngIf="hrefToTab.get(tab.href)?.groupKey">(Group: {{experimentNavigationGroup.groupKey}}.{{hrefToTab.get(tab.href)?.groupKey}})</mat-panel-description>
+                </mat-expansion-panel-header>
+                <p>TODO: CONTENT</p>
+            </mat-expansion-panel>
+        }
+    </mat-accordion>
+
+    @for (group of experimentNavigationGroups; track group.groupKey) {
+        <h4>
+            <mat-icon *ngIf="group.icon">{{group.icon}}</mat-icon>
+            {{group.name}}
+            <span class="group-title-extra">(Group: {{group.groupKey}})</span>
+        </h4>
+        <mat-accordion>
+            @for (tab of group.tabs; track tab.href) {
+                <mat-expansion-panel>
+                    <mat-expansion-panel-header>
+                        <mat-panel-title class="tab-title">
+                            <mat-icon *ngIf="hrefToTab.get(tab.href)?.icon">{{hrefToTab.get(tab.href)?.icon}}</mat-icon>
+                            {{tab.name}}
+                            <mat-icon *ngIf="hrefToTab.get(tab.href)?.groupKey">more_vert</mat-icon>
+                        </mat-panel-title>
+                        <mat-panel-description *ngIf="hrefToTab.get(tab.href)?.groupKey">(Group: {{group.groupKey}}.{{hrefToTab.get(tab.href)?.groupKey}})</mat-panel-description>
+                    </mat-expansion-panel-header>
+                    <p>TODO: CONTENT</p>
+                </mat-expansion-panel>
+            }
+        </mat-accordion>
+    }
+</div>
+<div *ngIf="unknownGroups.length > 0">
+    <h3>Unknown Tab Groups</h3>
+    @for (group of unknownGroups; track group.groupKey) {
+        <h4>
+            <mat-icon *ngIf="group.icon">{{group.icon}}</mat-icon>
+            {{group.name}}
+            <span class="group-title-extra">(Group: {{group.groupKey}})</span>
+        </h4>
+        <mat-accordion>
+            @for (tab of group.tabs; track tab.href) {
+                <mat-expansion-panel>
+                    <mat-expansion-panel-header>
+                        <mat-panel-title class="tab-title">
+                            <mat-icon *ngIf="hrefToTab.get(tab.href)?.icon">{{hrefToTab.get(tab.href)?.icon}}</mat-icon>
+                            {{tab.name}}
+                            <mat-icon *ngIf="hrefToTab.get(tab.href)?.groupKey">more_vert</mat-icon>
+                        </mat-panel-title>
+                        <mat-panel-description *ngIf="hrefToTab.get(tab.href)?.groupKey">(Group: {{group.groupKey}}.{{hrefToTab.get(tab.href)?.groupKey}})</mat-panel-description>
+                    </mat-expansion-panel-header>
+                    <p>TODO: CONTENT</p>
+                </mat-expansion-panel>
+            }
+        </mat-accordion>
+    }
+</div>

--- a/src/app/components-small/ui-template-tab-list/ui-template-tab-list.component.sass
+++ b/src/app/components-small/ui-template-tab-list/ui-template-tab-list.component.sass
@@ -1,0 +1,6 @@
+.tab-title
+    display: inline-flex
+    gap: 0.5rem
+
+.group-title-extra
+    color: var(--text-washed)

--- a/src/app/components-small/ui-template-tab-list/ui-template-tab-list.component.sass
+++ b/src/app/components-small/ui-template-tab-list/ui-template-tab-list.component.sass
@@ -4,3 +4,6 @@
 
 .group-title-extra
     color: var(--text-washed)
+
+.new-tab-button
+    margin-block-start: 1rem

--- a/src/app/components-small/ui-template-tab-list/ui-template-tab-list.component.ts
+++ b/src/app/components-small/ui-template-tab-list/ui-template-tab-list.component.ts
@@ -1,0 +1,334 @@
+import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { TemplateApiObject, TemplateTabApiObject } from 'src/app/services/templates.service';
+import { PluginRegistryBaseService } from 'src/app/services/registry.service';
+import { MatDialog } from '@angular/material/dialog';
+import { Subscription } from 'rxjs';
+import { ApiLink, CollectionApiObject } from 'src/app/services/api-data-types';
+
+interface NavTabGroup {
+    groupKey: string;
+    name: string;
+    icon?: string | null;
+    tabs: ApiLink[];
+}
+
+
+@Component({
+    selector: 'qhana-ui-template-tab-list',
+    templateUrl: './ui-template-tab-list.component.html',
+    styleUrl: './ui-template-tab-list.component.sass'
+})
+export class UiTemplateTabListComponent implements OnInit, OnChanges, OnDestroy {
+
+    @Input() templateLink: ApiLink | null = null;
+
+    navigationGroup: NavTabGroup | null = null;
+    workspaceGroup: NavTabGroup | null = null;
+    experimentNavigationGroup: NavTabGroup | null = null;
+    navigationGroups: NavTabGroup[] = [];
+    experimentNavigationGroups: NavTabGroup[] = [];
+    unknownGroups: NavTabGroup[] = [];
+
+    private allGroups: NavTabGroup[] = [];
+
+    hrefToTab: Map<string, TemplateTabApiObject> = new Map();
+
+    private newTabsSubscription: Subscription | null = null;
+    private changedTabsSubscription: Subscription | null = null;
+    private deletedTabsSubscription: Subscription | null = null;
+
+    constructor(private registry: PluginRegistryBaseService, private dialog: MatDialog) { }
+
+    ngOnInit(): void {
+        this.newTabsSubscription = this.registry.newApiObjectSubject.subscribe((apiObject) => {
+            if (apiObject.new.resourceType !== "ui-template-tab") {
+                return;
+            }
+            if (apiObject.new.resourceKey?.uiTemplateId !== this.templateLink?.resourceKey?.uiTemplateId) {
+                return;
+            }
+            this.updateTemplateTab(apiObject.new);
+        });
+        this.changedTabsSubscription = this.registry.changedApiObjectSubject.subscribe((apiObject) => {
+            if (apiObject.changed.resourceType !== "ui-template-tab") {
+                return;
+            }
+            if (apiObject.changed.resourceKey?.uiTemplateId !== this.templateLink?.resourceKey?.uiTemplateId) {
+                return;
+            }
+            this.updateTemplateTab(apiObject.changed);
+        });
+        this.deletedTabsSubscription = this.registry.deletedApiObjectSubject.subscribe((apiObject) => {
+            if (apiObject.deleted.resourceType !== "ui-template-tab") {
+                return;
+            }
+            if (apiObject.deleted.resourceKey?.uiTemplateId !== this.templateLink?.resourceKey?.uiTemplateId) {
+                return;
+            }
+            this.removeTemplateTab(apiObject.deleted);
+        });
+    }
+
+    ngOnDestroy(): void {
+        this.newTabsSubscription?.unsubscribe();
+        this.changedTabsSubscription?.unsubscribe();
+        this.deletedTabsSubscription?.unsubscribe();
+    }
+
+    ngOnChanges(changes: SimpleChanges): void {
+        this.loadTemplateGroups();
+    }
+
+    private async loadTemplateGroups() {
+        if (this.templateLink == null) {
+            this.hrefToTab = new Map();
+            this.workspaceGroup = null;
+            this.navigationGroup = null;
+            this.experimentNavigationGroup = null;
+            this.navigationGroups = [];
+            this.experimentNavigationGroups = [];
+            this.unknownGroups = [];
+            return;
+        }
+        const templateResponse = await this.registry.getByApiLink<TemplateApiObject>(this.templateLink, null, false);
+        if (templateResponse == null) {
+            this.hrefToTab = new Map();
+            this.workspaceGroup = null;
+            this.navigationGroup = null;
+            this.experimentNavigationGroup = null;
+            this.navigationGroups = [];
+            this.experimentNavigationGroups = [];
+            this.unknownGroups = [];
+            return;
+        }
+
+        const hrefToTab = new Map<string, TemplateTabApiObject>();
+
+        const tabPromises: Promise<unknown>[] = [];
+
+        let navGroup: NavTabGroup | null = null;
+        let workspace: NavTabGroup | null = null;
+        let expNavGroup: NavTabGroup | null = null;
+        const navGroups: NavTabGroup[] = [];
+        const expNavGroups: NavTabGroup[] = [];
+        const unknownGroups: NavTabGroup[] = [];
+
+        const allGroups: NavTabGroup[] = [];
+
+        const groupIcons = new Map<string, string>();
+
+        const groupPromises = templateResponse.data.groups.map(async (group) => {
+            const groupResponse = await this.registry.getByApiLink<CollectionApiObject>(group);
+
+            // fetch tab data
+            groupResponse?.data?.items?.forEach?.(tabLink => {
+                const prom = this.registry.getByApiLink<TemplateTabApiObject>(tabLink).then(tab => {
+                    if (tab) {
+                        hrefToTab.set(tab.data.self.href, tab.data);
+                        if (tab.data.groupKey && tab.data.icon) {
+                            groupIcons.set(`${tab.data.location}.${tab.data.groupKey}`, tab.data.icon);
+                        }
+                    }
+                });
+                tabPromises.push(prom);
+            });
+
+            const tabGroup: NavTabGroup = {
+                groupKey: group.resourceKey?.["?group"] ?? "unknwon",
+                name: group.name ?? "UNNAMED",
+                tabs: groupResponse?.data?.items ?? [],
+            };
+
+            allGroups.push(tabGroup);
+
+            if (tabGroup.groupKey === "workspace") {
+                workspace = tabGroup;
+            } else if (tabGroup.groupKey === "navigation") {
+                navGroup = tabGroup;
+            } else if (tabGroup.groupKey === "experiment-navigation") {
+                expNavGroup = tabGroup;
+            } else if (tabGroup.groupKey.startsWith("navigation")) {
+                navGroups.push(tabGroup);
+            } else if (tabGroup.groupKey.startsWith("experiment-navigation")) {
+                expNavGroups.push(tabGroup);
+            } else {
+                unknownGroups.push(tabGroup);
+            }
+        });
+
+        await Promise.allSettled(tabPromises);
+        await Promise.allSettled(groupPromises);
+
+        navGroups.forEach(g => {
+            g.icon = groupIcons.get(g.groupKey);
+        });
+        expNavGroups.forEach(g => {
+            g.icon = groupIcons.get(g.groupKey);
+        });
+        unknownGroups.forEach(g => {
+            g.icon = groupIcons.get(g.groupKey);
+        });
+
+        this.hrefToTab = hrefToTab;
+        this.navigationGroup = navGroup;
+        this.workspaceGroup = workspace;
+        this.experimentNavigationGroup = expNavGroup;
+        this.navigationGroups = navGroups;
+        this.experimentNavigationGroups = expNavGroups;
+        this.unknownGroups = unknownGroups;
+        this.allGroups = allGroups;
+    }
+
+    private async updateTemplateTab(tabLink: ApiLink) {
+        const tabResponse = await this.registry.getByApiLink<TemplateTabApiObject>(tabLink, null, false);
+        if (tabResponse == null) {
+            return; // cannot update tab
+        }
+
+        const groupLink = tabResponse.links.find(link => {
+            return link.resourceType === "ui-template-tab" && link.rel.some(r => r === "collection") && link.resourceKey?.["?group"];
+        }) ?? null;
+
+        const tab = tabResponse.data;
+
+        this.hrefToTab.set(tab.self.href, tab);
+
+        if (tab.location === "workspace") {
+            this.workspaceGroup = this.updateTabInGroup(this.workspaceGroup, tabLink, groupLink);
+        } else if (tab.location === "navigation") {
+            this.navigationGroup = this.updateTabInGroup(this.navigationGroup, tabLink, groupLink);
+        } else if (tab.location === "experiment-navigation") {
+            this.experimentNavigationGroup = this.updateTabInGroup(this.experimentNavigationGroup, tabLink, groupLink);
+        } else if (tab.location.startsWith("navigation")) {
+            if (this.navigationGroups.some(g => g.groupKey === tab.location)) {
+                this.navigationGroups.map(g => {
+                    if (g.groupKey === tab.location) {
+                        return this.updateTabInGroup(g, tabLink, groupLink);
+                    }
+                    return g;
+                })
+            } else {
+                this.navigationGroups.push(this.updateTabInGroup(null, tabLink, groupLink))
+            }
+        } else if (tab.location.startsWith("experiment-navigation")) {
+            if (this.experimentNavigationGroups.some(g => g.groupKey === tab.location)) {
+                this.experimentNavigationGroups.map(g => {
+                    if (g.groupKey === tab.location) {
+                        return this.updateTabInGroup(g, tabLink, groupLink);
+                    }
+                    return g;
+                })
+            } else {
+                this.experimentNavigationGroups.push(this.updateTabInGroup(null, tabLink, groupLink))
+            }
+        } else {
+            if (this.unknownGroups.some(g => g.groupKey === tab.location)) {
+                this.unknownGroups.map(g => {
+                    if (g.groupKey === tab.location) {
+                        return this.updateTabInGroup(g, tabLink, groupLink);
+                    }
+                    return g;
+                })
+            } else {
+                this.unknownGroups.push(this.updateTabInGroup(null, tabLink, groupLink))
+            }
+        }
+
+        this.removeOldTemplateTabLinkFromOtherGroups(tabLink);
+    }
+
+    private updateTabInGroup(group: NavTabGroup | null, tab: ApiLink, groupLink: ApiLink | null) {
+        if (group == null) {
+            if (groupLink != null) {
+                group = {
+                    groupKey: groupLink.resourceKey?.["?group"] ?? "unknwon",
+                    name: groupLink.name ?? "UNNAMED",
+                    tabs: [],
+                }
+            } else {
+                group = {
+                    groupKey: tab.resourceKey?.["?group"] ?? "unknwon",
+                    name: tab.resourceKey?.["?group"] ?? "UNNAMED",
+                    tabs: [],
+                }
+            }
+            group.icon = this.getGroupIcon(group.groupKey);
+            this.allGroups.push(group);
+        }
+        if (group.tabs.some(t => t.href === tab.href)) {
+            group.tabs.map(t => {
+                if (t.href === tab.href) {
+                    return tab;  // insert new
+                }
+                return t;  // keep original
+            });
+        } else {
+            group.tabs.push(tab);
+        }
+        return group;
+    }
+
+    private getGroupIcon(groupLocation: string) {
+        let icon: string | null = null;
+        this.hrefToTab.forEach((tab) => {
+            if (tab.groupKey && groupLocation.startsWith(tab.location)) {
+                if (groupLocation === `${tab.location}.${tab.groupKey}`) {
+                    icon = tab.icon;
+                }
+            }
+        });
+        return icon;
+    }
+
+    private async removeOldTemplateTabLinkFromOtherGroups(tabLink: ApiLink) {
+        let hasEmptyGroups = false;
+        this.allGroups.forEach(group => {
+            if (group.groupKey === tabLink.resourceKey?.["?group"]) {
+                // do not remove tab from the group it is currently in!
+                return;
+            }
+            if (group.tabs.some(t => t.href === tabLink.href)) {
+                group.tabs = group.tabs.filter(t => t.href !== t.href);
+            }
+            if (group.tabs.length === 0) {
+                hasEmptyGroups = true;
+            }
+        });
+        if (hasEmptyGroups) {
+            this.removeEmptyGroups();
+        }
+    }
+
+    private async removeTemplateTab(tabLink: ApiLink) {
+        let hasEmptyGroups = false;
+        this.allGroups.forEach(group => {
+            if (group.tabs.some(t => t.href === tabLink.href)) {
+                group.tabs = group.tabs.filter(t => t.href !== t.href);
+            }
+            if (group.tabs.length === 0) {
+                hasEmptyGroups = true;
+            }
+        });
+        if (hasEmptyGroups) {
+            this.removeEmptyGroups();
+        }
+        this.hrefToTab.delete(tabLink.href);
+    }
+
+    private removeEmptyGroups() {
+        this.allGroups = this.allGroups.filter(g => g.tabs.length > 0);
+        this.navigationGroups = this.navigationGroups.filter(g => g.tabs.length > 0);
+        this.experimentNavigationGroups = this.experimentNavigationGroups.filter(g => g.tabs.length > 0);
+        this.unknownGroups = this.unknownGroups.filter(g => g.tabs.length > 0);
+        if (this.navigationGroup?.tabs?.length === 0) {
+            this.navigationGroup = null;
+        }
+        if (this.workspaceGroup?.tabs?.length === 0) {
+            this.workspaceGroup = null;
+        }
+        if (this.experimentNavigationGroup?.tabs?.length === 0) {
+            this.experimentNavigationGroup = null;
+        }
+    }
+
+}

--- a/src/app/components-small/ui-template-tab/ui-template-tab.component.html
+++ b/src/app/components-small/ui-template-tab/ui-template-tab.component.html
@@ -1,0 +1,13 @@
+<div class="tab-header">
+    <div class="header-buttons">
+        <button mat-icon-button *ngIf="templateUpdateLink != null"><mat-icon>{{isEditing ? 'edit_off' : 'edit'}}</mat-icon></button>
+        <button mat-icon-button color="warn" *ngIf="templateDeleteLink != null"><mat-icon>delete</mat-icon></button>
+    </div>
+</div>
+<p>Description:  {{tabData?.description ? '' : '–'}}</p>
+<qhana-markdown [markdown]="tabData?.description ?? ''" [editable]="false" [hidden]="!tabData?.description"></qhana-markdown>
+@if(!isEditing && !(tabData?.groupKey ?? false) && tabFilterData) {
+    <p>Plugin filter:</p>
+    <qhana-plugin-filter-view [filter]="tabFilterData"></qhana-plugin-filter-view>
+}
+

--- a/src/app/components-small/ui-template-tab/ui-template-tab.component.html
+++ b/src/app/components-small/ui-template-tab/ui-template-tab.component.html
@@ -1,13 +1,19 @@
 <div class="tab-header">
     <div class="header-buttons">
-        <button mat-icon-button *ngIf="templateUpdateLink != null"><mat-icon>{{isEditing ? 'edit_off' : 'edit'}}</mat-icon></button>
-        <button mat-icon-button color="warn" *ngIf="templateDeleteLink != null"><mat-icon>delete</mat-icon></button>
+        <button mat-stroked-button (click)="tabFormChild.submitForm()" *ngIf="tabFormChild != null && isDirty"><mat-icon>save</mat-icon>save</button>
+        <button mat-icon-button (click)="isEditing = !isEditing" *ngIf="tabUpdateLink != null"><mat-icon>{{isEditing ? 'edit_off' : 'edit'}}</mat-icon></button>
+        <button mat-icon-button color="warn" (click)="deleteTab()" *ngIf="tabDeleteLink != null"><mat-icon>delete</mat-icon></button>
     </div>
 </div>
-<p>Description:  {{tabData?.description ? '' : '–'}}</p>
-<qhana-markdown [markdown]="tabData?.description ?? ''" [editable]="false" [hidden]="!tabData?.description"></qhana-markdown>
-@if(!isEditing && !(tabData?.groupKey ?? false) && tabFilterData) {
+@if (!isEditing) {
+    <p>Description: {{tabData?.description ? '' : '–'}}</p>
+    <qhana-markdown [markdown]="tabData?.description ?? ''" [editable]="false" [hidden]="!tabData?.description"></qhana-markdown>
+}
+@if (!isEditing && !(tabData?.groupKey ?? false) && tabFilterData) {
     <p>Plugin filter:</p>
     <qhana-plugin-filter-view [filter]="tabFilterData"></qhana-plugin-filter-view>
 }
-
+@if (isEditing) {
+    <qhana-ui-template-tab-form [tabData]="tabData" (isValid)="isValid = $event" (isDirty)="isDirty = $event" (data)="newData = $event" (formSubmit)="updateTab()" [hidden]="!isEditing" #tabForm></qhana-ui-template-tab-form>
+    <button mat-flat-button color="primary" (click)="tabFormChild.submitForm()" *ngIf="tabFormChild != null && isDirty"><mat-icon>save</mat-icon>save</button>
+}

--- a/src/app/components-small/ui-template-tab/ui-template-tab.component.sass
+++ b/src/app/components-small/ui-template-tab/ui-template-tab.component.sass
@@ -1,0 +1,6 @@
+.tab-header
+    display: flex
+    align-items: center
+    justify-content: flex-end
+    width: 100%
+    gap: 0.5rem

--- a/src/app/components-small/ui-template-tab/ui-template-tab.component.sass
+++ b/src/app/components-small/ui-template-tab/ui-template-tab.component.sass
@@ -4,3 +4,9 @@
     justify-content: flex-end
     width: 100%
     gap: 0.5rem
+    margin-block-end: 0.5rem
+
+.header-buttons
+    display: flex
+    align-items: center
+    gap: 0.5rem

--- a/src/app/components-small/ui-template-tab/ui-template-tab.component.ts
+++ b/src/app/components-small/ui-template-tab/ui-template-tab.component.ts
@@ -1,0 +1,65 @@
+import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { ApiLink } from 'src/app/services/api-data-types';
+import { PluginRegistryBaseService } from 'src/app/services/registry.service';
+import { TemplateTabApiObject } from 'src/app/services/templates.service';
+
+@Component({
+    selector: 'qhana-ui-template-tab',
+    templateUrl: './ui-template-tab.component.html',
+    styleUrl: './ui-template-tab.component.sass'
+})
+export class UiTemplateTabComponent implements OnChanges, OnInit, OnDestroy {
+
+    @Input() tabLink: ApiLink | null = null;
+
+    tabData: TemplateTabApiObject | null = null;
+    tabFilterData: any = null;
+    templateUpdateLink: ApiLink | null = null;
+    templateDeleteLink: ApiLink | null = null;
+
+    isEditing: boolean = false;
+
+    private updateSubscription: Subscription | null = null;
+
+    constructor(private registry: PluginRegistryBaseService) { }
+
+    ngOnInit(): void {
+        this.updateSubscription = this.registry.apiObjectSubject.subscribe((apiObject) => {
+            if (apiObject.self.href !== this.tabLink?.href) {
+                return;
+            }
+            if (apiObject.self.resourceType === "ui-template-tab") {
+                this.tabData = apiObject as TemplateTabApiObject;
+            }
+        });
+    }
+
+    ngOnDestroy(): void {
+        this.updateSubscription?.unsubscribe();
+    }
+
+    ngOnChanges(changes: SimpleChanges): void {
+        this.loadTemplateTab();
+    }
+
+    private async loadTemplateTab() {
+        if (this.tabLink == null) {
+            this.tabData = null;
+            return;
+        }
+        const tabResponse = await this.registry.getByApiLink<TemplateTabApiObject>(this.tabLink, null, true);
+        this.tabData = tabResponse?.data ?? null;
+
+        if (tabResponse?.data?.filterString) {
+            try {
+                this.tabFilterData = JSON.parse(tabResponse?.data?.filterString);
+            } catch {
+                // Ignore error
+            }
+        }
+
+        this.templateUpdateLink = tabResponse?.links?.find?.(link => link.rel.some(rel => rel === "update") && link.resourceType == "ui-template-tab") ?? null;
+        this.templateDeleteLink = tabResponse?.links?.find?.(link => link.rel.some(rel => rel === "delete") && link.resourceType == "ui-template-tab") ?? null;
+    }
+}

--- a/src/app/components-small/ui-template/ui-template.component.html
+++ b/src/app/components-small/ui-template/ui-template.component.html
@@ -1,0 +1,42 @@
+<mat-card appearance="outlined" class="card" *ngIf="templateData != null">
+    <mat-card-title class="t-headline header">
+        <div [hidden]="isEditing">
+            UI Template: {{templateData.name}}
+        </div>
+        <mat-form-field class="name-field" [hidden]="!isEditing">
+            <mat-label>UI Template Name:</mat-label>
+            <input matInput [(ngModel)]="currentName">
+        </mat-form-field>
+        <div class="header-buttons">
+            <button mat-stroked-button (click)="updateTemplate()" *ngIf="isDirty"><mat-icon>save</mat-icon>save</button>
+            <button mat-icon-button (click)="toggleEdit()" *ngIf="templateUpdateLink != null"><mat-icon>{{isEditing ? 'edit_off' : 'edit'}}</mat-icon></button>
+            <button mat-icon-button (click)="deleteTemplate()" color="warn" *ngIf="templateDeleteLink != null"><mat-icon>delete</mat-icon></button>
+        </div>
+    </mat-card-title>
+    <mat-card-content class="content">
+        <mat-chip-set class="tags" [hidden]="isEditing">
+            <mat-chip *ngFor="let tag of templateData.tags">{{tag}}</mat-chip>
+        </mat-chip-set>
+        <mat-form-field class="tags-field" *ngIf="isEditing">
+            <mat-label>Tags</mat-label>
+            <mat-chip-grid #chipGrid>
+              @for (tag of currentTags; track tag) {
+                <mat-chip-row
+                  (removed)="removeTag(tag)"
+                >
+                  {{tag}}
+                  <button matChipRemove [attr.aria-label]="'remove ' + tag">
+                    <mat-icon>cancel</mat-icon>
+                  </button>
+                </mat-chip-row>
+              }
+              <input
+                placeholder="New Tag"
+                [matChipInputFor]="chipGrid"
+                (matChipInputTokenEnd)="addTag($event)"
+              />
+            </mat-chip-grid>
+          </mat-form-field>
+        <qhana-markdown [editable]="isEditing" [markdown]="templateData.description" (markdownChanges)="currentDescription = $event"></qhana-markdown>
+    </mat-card-content>
+</mat-card>

--- a/src/app/components-small/ui-template/ui-template.component.html
+++ b/src/app/components-small/ui-template/ui-template.component.html
@@ -1,3 +1,10 @@
+<mat-card appearance="outlined" class="card" *ngIf="templateData == null">
+    <mat-card-title class="t-headline header">
+        Loading...
+    </mat-card-title>
+    <mat-card-content class="content"></mat-card-content>
+</mat-card>
+
 <mat-card appearance="outlined" class="card" *ngIf="templateData != null">
     <mat-card-title class="t-headline header">
         <div [hidden]="isEditing">
@@ -40,6 +47,6 @@
               />
             </mat-chip-grid>
           </mat-form-field>
-        <qhana-markdown [editable]="isEditing" [markdown]="templateData.description" (markdownChanges)="currentDescription = $event"></qhana-markdown>
+        <qhana-markdown class="{{isEditing ? 'qhana-form-input' : ''}}" style="display: block;" [editable]="isEditing" [markdown]="templateData.description" (markdownChanges)="currentDescription = $event"></qhana-markdown>
     </mat-card-content>
 </mat-card>

--- a/src/app/components-small/ui-template/ui-template.component.html
+++ b/src/app/components-small/ui-template/ui-template.component.html
@@ -9,6 +9,9 @@
         </mat-form-field>
         <div class="header-buttons">
             <button mat-stroked-button (click)="updateTemplate()" *ngIf="isDirty"><mat-icon>save</mat-icon>save</button>
+            <button mat-icon-button (click)="toggleEnvDefault()">
+                <mat-icon>{{(templateLink && currentEnvDefaultTemplate === templateLink.resourceKey?.uiTemplateId) ? 'star' : 'star_outline'}}</mat-icon>
+            </button>
             <button mat-icon-button (click)="toggleEdit()" *ngIf="templateUpdateLink != null"><mat-icon>{{isEditing ? 'edit_off' : 'edit'}}</mat-icon></button>
             <button mat-icon-button (click)="deleteTemplate()" color="warn" *ngIf="templateDeleteLink != null"><mat-icon>delete</mat-icon></button>
         </div>

--- a/src/app/components-small/ui-template/ui-template.component.sass
+++ b/src/app/components-small/ui-template/ui-template.component.sass
@@ -1,0 +1,23 @@
+.header
+    display: flex
+    align-items: center
+    justify-content: space-between
+    gap: 1rem
+
+.header-buttons
+    display: flex
+    align-items: center
+    gap: 0.5rem
+
+.content, .content:last-child
+    padding: 0
+    margin-block-start: 0.5rem
+
+.name-field
+    flex-grow: 1
+
+.tags
+    margin-block-end: 0.5rem
+
+.tags-field
+    width: 100%

--- a/src/app/components-small/ui-template/ui-template.component.sass
+++ b/src/app/components-small/ui-template/ui-template.component.sass
@@ -1,6 +1,6 @@
 .header
     display: flex
-    align-items: center
+    align-items: flex-start
     justify-content: space-between
     gap: 1rem
 
@@ -21,3 +21,6 @@
 
 .tags-field
     width: 100%
+
+.qhana-form-input
+    border-width: 1px

--- a/src/app/components-small/ui-template/ui-template.component.ts
+++ b/src/app/components-small/ui-template/ui-template.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { ApiLink, ChangedApiObject } from 'src/app/services/api-data-types';
+import { ApiLink } from 'src/app/services/api-data-types';
 import { TemplateApiObject } from 'src/app/services/templates.service';
 import { PluginRegistryBaseService } from 'src/app/services/registry.service';
 import { MatChipInputEvent } from '@angular/material/chips';
@@ -61,11 +60,11 @@ export class UiTemplateComponent implements OnChanges, OnInit, OnDestroy {
             this.templateData = null;
             return;
         }
-        const templateResponse = await this.registry.getByApiLink<TemplateApiObject>(this.templateLink);
+        const templateResponse = await this.registry.getByApiLink<TemplateApiObject>(this.templateLink, null, true);
         this.templateData = templateResponse?.data ?? null;
 
-        this.templateUpdateLink = templateResponse?.links?.find(link => link.rel.some(rel => rel === "update") && link.resourceType == "ui-template") ?? null;
-        this.templateDeleteLink = templateResponse?.links?.find(link => link.rel.some(rel => rel === "delete") && link.resourceType == "ui-template") ?? null;
+        this.templateUpdateLink = templateResponse?.links?.find?.(link => link.rel.some(rel => rel === "update") && link.resourceType == "ui-template") ?? null;
+        this.templateDeleteLink = templateResponse?.links?.find?.(link => link.rel.some(rel => rel === "delete") && link.resourceType == "ui-template") ?? null;
     }
 
     get isDirty() {

--- a/src/app/components-small/ui-template/ui-template.component.ts
+++ b/src/app/components-small/ui-template/ui-template.component.ts
@@ -1,0 +1,144 @@
+import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ApiLink, ChangedApiObject } from 'src/app/services/api-data-types';
+import { TemplateApiObject } from 'src/app/services/templates.service';
+import { PluginRegistryBaseService } from 'src/app/services/registry.service';
+import { MatChipInputEvent } from '@angular/material/chips';
+import { Subscription } from 'rxjs';
+import { MatDialog } from '@angular/material/dialog';
+import { DeleteDialog } from 'src/app/dialogs/delete-dialog/delete-dialog.dialog';
+
+@Component({
+    selector: 'qhana-ui-template',
+    templateUrl: './ui-template.component.html',
+    styleUrl: './ui-template.component.sass'
+})
+export class UiTemplateComponent implements OnChanges, OnInit, OnDestroy {
+
+    @Input() templateLink: ApiLink | null = null;
+
+
+    templateData: TemplateApiObject | null = null;
+    templateUpdateLink: ApiLink | null = null;
+    templateDeleteLink: ApiLink | null = null;
+
+    isEditing: boolean = false;
+
+    currentName: string | null = null;
+    currentTags: string[] | null = null;
+    currentDescription: string | null = null;
+
+    private tagsDirty: boolean = false;
+    private updateSubscription: Subscription | null = null;
+
+    constructor(private registry: PluginRegistryBaseService, private dialog: MatDialog) { }
+
+    ngOnInit(): void {
+        this.updateSubscription = this.registry.apiObjectSubject.subscribe((apiObject) => {
+            if (apiObject.self.href !== this.templateLink?.href) {
+                return;
+            }
+            if (apiObject.self.resourceType === "ui-template") {
+                this.templateData = apiObject as TemplateApiObject;
+                if (this.isEditing) {
+                    this.currentTags = [...(apiObject as TemplateApiObject).tags];
+                    this.tagsDirty = false;
+                }
+            }
+        });
+    }
+
+    ngOnDestroy(): void {
+        this.updateSubscription?.unsubscribe();
+    }
+
+    ngOnChanges(changes: SimpleChanges): void {
+        this.loadTemplate();
+    }
+
+    private async loadTemplate() {
+        if (this.templateLink == null) {
+            this.templateData = null;
+            return;
+        }
+        const templateResponse = await this.registry.getByApiLink<TemplateApiObject>(this.templateLink);
+        this.templateData = templateResponse?.data ?? null;
+
+        this.templateUpdateLink = templateResponse?.links?.find(link => link.rel.some(rel => rel === "update") && link.resourceType == "ui-template") ?? null;
+        this.templateDeleteLink = templateResponse?.links?.find(link => link.rel.some(rel => rel === "delete") && link.resourceType == "ui-template") ?? null;
+    }
+
+    get isDirty() {
+        if (!this.isEditing) {
+            return false;
+        }
+        if (this.currentName !== this.templateData?.name) {
+            return true;
+        }
+        if (this.currentDescription !== this.templateData?.description) {
+            return true;
+        }
+        if (this.tagsDirty) {
+            return true;
+        }
+        return false;
+    }
+
+    toggleEdit() {
+        if (this.templateData == null || this.templateUpdateLink == null) {
+            this.isEditing = false;
+        } else {
+            this.isEditing = !this.isEditing;
+        }
+        if (this.isEditing) {
+            this.currentName = this.templateData?.name ?? null;
+            this.currentTags = [...(this.templateData?.tags ?? [])];
+            this.currentDescription = this.templateData?.description ?? null;
+            this.tagsDirty = false;
+        } else {
+            this.currentName = null;
+            this.currentTags = null;
+            this.currentDescription = null;
+            this.tagsDirty = false;
+        }
+    }
+
+    removeTag(tag: string) {
+        this.currentTags = this.currentTags?.filter(t => t !== tag) ?? null;
+        this.tagsDirty = true;
+    }
+
+    addTag(event: MatChipInputEvent) {
+        const tag = event.value;
+        this.currentTags?.push(tag);
+        this.tagsDirty = true;
+    }
+
+    async updateTemplate() {
+        if (!this.isDirty || this.templateUpdateLink == null) {
+            return;
+        }
+
+        this.registry.submitByApiLink(this.templateUpdateLink, {
+            name: this.currentName,
+            description: this.currentDescription,
+            tags: this.currentTags,
+        });
+    }
+
+    async deleteTemplate() {
+        if (this.templateDeleteLink == null) {
+            return;
+        }
+
+        const dialogRef = this.dialog.open(DeleteDialog, {
+            data: this.templateLink,
+        });
+
+        const doDelete = await dialogRef.afterClosed().toPromise();
+        if (doDelete) {
+            this.registry.submitByApiLink(this.templateDeleteLink);
+        }
+    }
+
+}

--- a/src/app/components/markdown/markdown.component.ts
+++ b/src/app/components/markdown/markdown.component.ts
@@ -358,14 +358,14 @@ export class MarkdownComponent implements OnChanges {
             // });
         }
         if (changes.editable != null) {
-            this.editor?.action(forceUpdate);
+            this.editor?.action(forceUpdate());
         }
     }
 
     resetEditMode() {
         if (this.editable) {
             this.showAsPreview = false;
-            this.editor?.action(forceUpdate);
+            this.editor?.action(forceUpdate());
         }
     }
 

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -4,6 +4,17 @@
         <span>{{title}}</span>
     </a>
 
+    <ng-container *ngIf="(currentExperiment|async) == null">
+        <a class="navigation-link" mat-button [routerLink]="['/']"
+            routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+            Experiments
+        </a>
+        <a class="navigation-link" mat-button [routerLink]="['/templates']"
+            queryParamsHandling="merge" routerLinkActive="active">
+            UI Templates
+        </a>
+    </ng-container>
+
     <ng-container *ngIf="(currentExperiment|async) != null">
         <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'info']"
             routerLinkActive="active">

--- a/src/app/components/ui-templates-page/ui-templates-page.component.html
+++ b/src/app/components/ui-templates-page/ui-templates-page.component.html
@@ -13,6 +13,7 @@
     <div class="content-container">
         <div class="main-content">
             <!--qhana-experiment-workspace-detail></qhana-experiment-workspace-detail-->
+            <qhana-ui-template [templateLink]="selectedTemplate"></qhana-ui-template>
             <div class="scroll-spacer"></div>
         </div>
     </div>

--- a/src/app/components/ui-templates-page/ui-templates-page.component.html
+++ b/src/app/components/ui-templates-page/ui-templates-page.component.html
@@ -14,6 +14,7 @@
         <div class="main-content">
             <!--qhana-experiment-workspace-detail></qhana-experiment-workspace-detail-->
             <qhana-ui-template [templateLink]="selectedTemplate"></qhana-ui-template>
+            <qhana-ui-template-tab-list class="template-tabs" [templateLink]="selectedTemplate"></qhana-ui-template-tab-list>
             <div class="scroll-spacer"></div>
         </div>
     </div>

--- a/src/app/components/ui-templates-page/ui-templates-page.component.html
+++ b/src/app/components/ui-templates-page/ui-templates-page.component.html
@@ -1,0 +1,19 @@
+<div class="templates-content">
+    <div class="sidebar color-scheme-card">
+        <h2 class="sidebar-header">Templates:</h2>
+        <button class="new-template-button" mat-stroked-button (click)="createTemplate()">
+            Create Template
+        </button>
+        <mat-divider></mat-divider>
+        <qhana-growing-list [rels]="['ui-template', 'collection']" [newItemRels]="['ui-template']"
+            [highlighted]="highlightedTemplates" [highlightByKey]="'uiTemplateId'"
+            (clickItem)="selectTemplate($event)"></qhana-growing-list>
+        <mat-divider></mat-divider>
+    </div>
+    <div class="content-container">
+        <div class="main-content">
+            <!--qhana-experiment-workspace-detail></qhana-experiment-workspace-detail-->
+            <div class="scroll-spacer"></div>
+        </div>
+    </div>
+</div>

--- a/src/app/components/ui-templates-page/ui-templates-page.component.sass
+++ b/src/app/components/ui-templates-page/ui-templates-page.component.sass
@@ -47,6 +47,7 @@
 .content-container .main-content
     max-width: 60rem
     margin-inline: auto
+    padding-block-start: 2rem
 
 .title
     display: flex

--- a/src/app/components/ui-templates-page/ui-templates-page.component.sass
+++ b/src/app/components/ui-templates-page/ui-templates-page.component.sass
@@ -57,12 +57,6 @@
 .spacer
     flex-grow: 1
 
-.card-list
-    margin-inline: -16px
-
-.active-list-item
-    background-color: var(--primary-lighter)
-    color: var(--text-primary)
-
-.active-list-item:focus
-    background-color: var(--primary-lighter)
+.template-tabs
+    display: block
+    margin-block-start: 2rem

--- a/src/app/components/ui-templates-page/ui-templates-page.component.sass
+++ b/src/app/components/ui-templates-page/ui-templates-page.component.sass
@@ -1,0 +1,67 @@
+.templates-content
+    display: grid
+    grid-template-areas: "sidebar main spacer"
+    grid-template-columns: minmax(min-content, calc( (100vw - 60rem)/2 )) minmax(20rem, 1fr) minmax(0.5rem, calc( (100vw - 60rem)/2 ))
+    grid-template-rows: 1fr
+
+.sidebar
+    position: sticky
+    top: 0px
+    grid-area: sidebar
+    margin-inline-end: 0.5rem
+    min-height: 100vh
+    display: flex
+    flex-direction: column
+    min-width: 15rem
+    width: 25vw
+    max-width: 20rem
+    padding-block-end: 4rem
+    background: var(--background)
+    border-inline-end: 1px solid var(--border-color)
+
+@media (prefers-color-scheme: dark)
+    .sidebar
+        border-right: none
+
+.new-template-button
+    margin-block: 1rem
+    margin-inline: 1rem
+
+.sidebar-header
+    display: flex
+    gap: 0.3rem
+    align-content: center
+    justify-content: space-between
+    padding-inline: 1rem
+
+.w-100
+    width: 100%
+
+.full-width
+    width: calc(100% - 2rem)
+    margin-inline: 1rem
+
+.content-container
+    grid-area: main
+
+.content-container .main-content
+    max-width: 60rem
+    margin-inline: auto
+
+.title
+    display: flex
+    justify-content: space-between
+    align-items: center
+
+.spacer
+    flex-grow: 1
+
+.card-list
+    margin-inline: -16px
+
+.active-list-item
+    background-color: var(--primary-lighter)
+    color: var(--text-primary)
+
+.active-list-item:focus
+    background-color: var(--primary-lighter)

--- a/src/app/components/ui-templates-page/ui-templates-page.component.ts
+++ b/src/app/components/ui-templates-page/ui-templates-page.component.ts
@@ -1,0 +1,88 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { ChangeUiTemplateDialog } from 'src/app/dialogs/change-ui-template/change-ui-template.dialog';
+import { ApiLink, PageApiObject } from 'src/app/services/api-data-types';
+import { PluginRegistryBaseService } from 'src/app/services/registry.service';
+import { TemplateApiObject, TemplatesService } from 'src/app/services/templates.service';
+
+@Component({
+    selector: 'qhana-ui-templates-page',
+    templateUrl: './ui-templates-page.component.html',
+    styleUrl: './ui-templates-page.component.sass'
+})
+export class UiTemplatesPageComponent implements OnInit, OnDestroy {
+    selectedTemplate: ApiLink | null = null;
+
+    highlightedTemplates: Set<string> = new Set();
+
+    templateId: string | null = null;
+    private routeParamSubscription: Subscription | null = null;
+
+
+    constructor(private route: ActivatedRoute, private router: Router, private registry: PluginRegistryBaseService, private templates: TemplatesService, private dialog: MatDialog) { }
+
+
+    ngOnInit(): void {
+        this.routeParamSubscription = this.route.paramMap.subscribe(params => {
+            let templateId = params.get('templateId');
+            if (templateId != null) {
+                this.highlightedTemplates = new Set<string>([templateId]);
+            } else {
+                this.highlightedTemplates.clear();
+            }
+            console.log(this.highlightedTemplates, templateId)
+            this.loadActiveTemplateFromId(templateId);
+        });
+
+    }
+
+    ngOnDestroy(): void {
+        this.routeParamSubscription?.unsubscribe();
+    }
+
+    selectTemplate(templateLink: ApiLink | null) {
+        console.log(templateLink)
+        if (templateLink == null) {
+            this.router.navigate(["/templates"]);
+            return;
+        }
+        this.selectedTemplate = templateLink;
+        this.router.navigate(["/templates", templateLink.resourceKey?.uiTemplateId ?? null]);
+    }
+
+    private async loadActiveTemplateFromId(newTemplateId: string | null) {
+        if (newTemplateId == null) {
+            this.selectedTemplate = null;
+            this.highlightedTemplates = new Set();
+            return;
+        }
+        const activeTemplateId = this.selectedTemplate?.resourceKey?.uiTemplateId ?? null;
+        if (newTemplateId === activeTemplateId) {
+            // nothing to do, link already loaded
+            return;
+        }
+        // need to fetch template api link from plugin registry
+        const query = new URLSearchParams();
+        query.set("template-id", newTemplateId);
+        const templatePage = await this.registry.getByRel<PageApiObject>([["ui-template", "collection"]], query, true);
+        if (templatePage?.data.collectionSize === 1) {
+            // only expect one template since IDs are unique
+            this.selectedTemplate = templatePage.data.items[0];
+        } else {
+            console.warn(`Template API returned an ambiguous response for template id ${newTemplateId}`, templatePage);
+        }
+    }
+
+
+    async createTemplate() {
+        const dialogRef = this.dialog.open(ChangeUiTemplateDialog, { data: { template: null }, minWidth: "20rem", maxWidth: "40rem", width: "60%" });
+        const templateData: TemplateApiObject = await dialogRef.afterClosed().toPromise();
+
+        if (!templateData) {
+            return;
+        }
+        this.templates.addTemplate(templateData);
+    }
+}

--- a/src/app/dialogs/change-ui-template/change-ui-template.dialog.html
+++ b/src/app/dialogs/change-ui-template/change-ui-template.dialog.html
@@ -1,5 +1,5 @@
 <h1 mat-dialog-title>{{data.template ? 'Update' : 'Create'}} UI Template</h1>
-<div mat-dialog-content>
+<div mat-dialog-content class="dialog-content">
     <div>
         <mat-form-field class="form-field">
             <mat-label>Name</mat-label>

--- a/src/app/dialogs/change-ui-template/change-ui-template.dialog.sass
+++ b/src/app/dialogs/change-ui-template/change-ui-template.dialog.sass
@@ -3,3 +3,6 @@
 
 .description-textarea
     min-height: 20ex
+
+.dialog-content
+    padding-top: 0.5rem

--- a/src/app/dialogs/delete-dialog/delete-dialog.dialog.ts
+++ b/src/app/dialogs/delete-dialog/delete-dialog.dialog.ts
@@ -6,6 +6,8 @@ const RESOURCE_TYPE_TO_TEXT: { [props: string]: string } = {
     'resource': 'resource',
     'seed': 'seed url',
     'service': 'service entry',
+    'ui-template': 'UI template',
+    'ui-template-tab': 'UI template tab',
 }
 
 @Component({

--- a/src/styles.sass
+++ b/src/styles.sass
@@ -52,7 +52,7 @@ $my-dark-theme: mat.define-dark-theme((color: (primary: $my-primary,accent: $my-
     // line is for milkdown
     --line: 150,150,150
 
-.mat-mdc-card, .color-scheme-card
+.mat-mdc-card, .mat-expansion-panel, .color-scheme-card
     --background: #{mat.get-color-from-palette(mat.$light-theme-background-palette, 'card')}
     --background-card: #bbb
     --border-color: #ddd
@@ -105,7 +105,23 @@ $my-dark-theme: mat.define-dark-theme((color: (primary: $my-primary,accent: $my-
         // line is for milkdown
         --line: 170,170,170
 
-    .mat-mdc-card, .color-scheme-card
+        // material theme token overrides for better dark mode text contrast
+        --mat-option-selected-state-label-text-color: var(--primary-text)
+        --mdc-filled-text-field-caret-color: var(--primary-text)
+        --mdc-filled-text-field-focus-active-indicator-color: var(--primary-text)
+        --mdc-filled-text-field-focus-label-text-color: rgba(179, 136, 255, 0.87)
+        --mdc-outlined-text-field-caret-color: var(--primary-text)
+        --mdc-outlined-text-field-focus-outline-color: var(--primary-text)
+        --mdc-outlined-text-field-focus-label-text-color: rgba(179, 136, 255, 0.87)
+        --mat-form-field-focus-select-arrow-color: rgba(179, 136, 255, 0.87)
+        --mat-select-focused-arrow-color: rgba(179, 136, 255, 0.87)
+        --mdc-circular-progress-active-indicator-color: var(--primary-text)
+        --mat-badge-background-color: var(--primary-text)
+        --mat-stepper-header-selected-state-icon-background-color: var(--primary-text)
+        --mat-stepper-header-done-state-icon-background-color: var(--primary-text)
+        --mat-stepper-header-edit-state-icon-background-color: var(--primary-text)
+
+    .mat-mdc-card, .mat-expansion-panel, .color-scheme-card
         --background: #{mat.get-color-from-palette(mat.$dark-theme-background-palette, 'card')}
         --background-card: #{mat.get-color-from-palette(mat.$dark-theme-background-palette, 'background')}
         --border-color: #888
@@ -130,6 +146,9 @@ $my-dark-theme: mat.define-dark-theme((color: (primary: $my-primary,accent: $my-
     .card.mat-mdc-card
         box-shadow: none
         border: 2px solid var(--border-color)
+
+    :root .mat-primary .mat-pseudo-checkbox-checked.mat-pseudo-checkbox-minimal::after, :root .mat-primary .mat-pseudo-checkbox-indeterminate.mat-pseudo-checkbox-minimal::after
+        color: var(--primary-text)
 
     :root // color contrast fixes:
 


### PR DESCRIPTION
Add a UI template editor that can be used outside of the experiment workspace.

- [x] List all templates
- [x] Create/delete templates
- [x] Edit template name/description/tags
- [x] Display tab goups and tabs (without tab content)
- [x] Display template tab content
- [x] Edit template tabs
- [x] Maybe: Set default template using env var in plugin registry

Fix update bug in markdown component.