### PR TITLE
Add components to show help directly on the page

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -94,6 +94,8 @@ import { UiTemplateTabComponent } from './components-small/ui-template-tab/ui-te
 import { PluginFilterViewComponent } from './components-small/plugin-filter-view/plugin-filter-view.component';
 import { UiTemplateTabFormComponent } from './components-small/ui-template-tab-form/ui-template-tab-form.component';
 import { PluginFilterFormComponent } from './components-small/plugin-filter-form/plugin-filter-form.component';
+import { HelpTooltipComponent } from "src/app/components-small/help-tooltip/help-tooltip.component";
+import { HelpToggleComponent } from "src/app/components-small/help-toggle/help-toggle.component";
 
 @NgModule({
     declarations: [
@@ -181,6 +183,8 @@ import { PluginFilterFormComponent } from './components-small/plugin-filter-form
         MatMenuModule,
         MatBadgeModule,
         MatRadioModule,
+        HelpTooltipComponent,
+        HelpToggleComponent
     ],
     providers: [
         { provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: "outline" } }

--- a/src/app/components-small/help-toggle/help-toggle.component.html
+++ b/src/app/components-small/help-toggle/help-toggle.component.html
@@ -1,0 +1,4 @@
+<button mat-icon-button [attr.aria-label]="showHelpButtons ? 'Hide help buttons' : 'Show help buttons'"
+    [attr.aria-pressed]="showHelpButtons" (click)="toggleHelp()">
+    <mat-icon [color]="showHelpButtons ? 'accent' : 'text'" aria-hidden="true">help</mat-icon>
+</button>

--- a/src/app/components-small/help-toggle/help-toggle.component.ts
+++ b/src/app/components-small/help-toggle/help-toggle.component.ts
@@ -1,0 +1,36 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from "@angular/material/button";
+import { Subscription } from 'rxjs';
+import { HelpServiceService } from 'src/app/services/help-service.service';
+import { MatIconModule } from "@angular/material/icon";
+import { MatButtonToggleModule } from "@angular/material/button-toggle";
+
+@Component({
+    selector: 'qhana-help-toggle',
+    standalone: true,
+    imports: [CommonModule, MatButtonModule, MatIconModule, MatButtonToggleModule],
+    templateUrl: './help-toggle.component.html',
+    styleUrl: './help-toggle.component.sass'
+})
+export class HelpToggleComponent {
+
+    private showHelpSubscription: Subscription | null = null;
+
+    showHelpButtons: boolean = false;
+
+    constructor(private helpService: HelpServiceService) { }
+
+    ngOnInit(): void {
+        this.showHelpSubscription = this.helpService.showHelp.subscribe((value) => this.showHelpButtons = value);
+    }
+
+    ngOnDestroy(): void {
+        this.showHelpSubscription?.unsubscribe();
+    }
+
+    toggleHelp(): void {
+        this.helpService.toggleShowHelp();
+    }
+
+}

--- a/src/app/components-small/help-tooltip/help-tooltip.component.html
+++ b/src/app/components-small/help-tooltip/help-tooltip.component.html
@@ -1,0 +1,6 @@
+<button class="tooltip-button" [style]="{'position-anchor': '--' + anchorId}"
+    [attr.aria-label]="label" [hidden]="!showHelpButton"
+    [attr.popovertarget]="anchorId" popovertargetaction="toggle">?</button>
+<div class="tooltip-content color-scheme-card" [id]="anchorId" [style]="{'position-anchor': '--' + anchorId}" popover="auto" [hidden]="!showHelpButton">
+    <ng-content></ng-content>
+</div>

--- a/src/app/components-small/help-tooltip/help-tooltip.component.sass
+++ b/src/app/components-small/help-tooltip/help-tooltip.component.sass
@@ -1,0 +1,49 @@
+:host
+    display: contents
+
+.tooltip-button
+    width: 1.3rem
+    height: 1.3rem
+    padding: 0px
+    background-color: var(--accent, orange)
+    color: var(--text-accent, black)
+    border: none
+    border-radius: 100%
+    display: flex
+    justify-content: center
+    align-items: center
+    font-weight: 700
+    transition-property: width, height
+    transition-duration: 0.3s
+    @supports (position-anchor: --anchor)
+        position: absolute
+        top: calc(anchor(top) - 0.3rem)
+        right: calc(anchor(right) - 0.3rem)
+        z-index: 1
+
+.tooltip-button:hover, .tooltip-button:focus
+    width: 1.5rem
+    height: 1.5rem
+
+.tooltip-content
+    background-color: var(--background, white)
+    color: var(--text, black)
+    border-color: var(--border-color)
+    border-radius: 0.4rem
+    font-size: initial
+    line-height: initial
+    max-width: 60ch
+    text-wrap: auto
+    padding: 1rem
+    @supports (position-anchor: --anchor)
+        position: absolute
+        position-area: bottom span-right
+        position-try-fallbacks: bottom span-left, right, left, top span-right, top span-left
+        margin: 0.1rem
+
+::ng-deep.tooltip-content p
+    margin-block: 0px
+
+@supports not (position-anchor: --anchor)
+    .tooltip-content::backdrop
+        background-color: #00000077

--- a/src/app/components-small/help-tooltip/help-tooltip.component.ts
+++ b/src/app/components-small/help-tooltip/help-tooltip.component.ts
@@ -1,0 +1,37 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { MatButtonModule } from "@angular/material/button";
+import { MatIconModule } from "@angular/material/icon";
+import { nanoid } from 'nanoid';
+import { Subscription } from 'rxjs';
+import { HelpServiceService } from 'src/app/services/help-service.service';
+
+@Component({
+    selector: 'qhana-help-tooltip',
+    standalone: true,
+    imports: [CommonModule, MatButtonModule, MatIconModule],
+    templateUrl: './help-tooltip.component.html',
+    styleUrl: './help-tooltip.component.sass'
+})
+export class HelpTooltipComponent implements OnInit, OnDestroy {
+
+    private showHelpSubscription: Subscription | null = null;
+
+    showHelpButton: boolean = false;
+    anchorId: string = nanoid()
+
+    @Input() label: string | null = null;
+    @Output() anchor: EventEmitter<string> = new EventEmitter();
+
+    constructor(private helpService: HelpServiceService) { }
+
+    ngOnInit(): void {
+        Promise.resolve().then(() => this.anchor.emit(this.anchorId));
+        this.showHelpSubscription = this.helpService.showHelp.subscribe((value) => this.showHelpButton = value);
+    }
+
+    ngOnDestroy(): void {
+        this.showHelpSubscription?.unsubscribe();
+    }
+
+}

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -6,13 +6,27 @@
 
     <ng-container *ngIf="(currentExperiment|async) == null">
         <a class="navigation-link" mat-button [routerLink]="['/']"
-            routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+            routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}"
+            [style]="{'anchor-name': '--' + (experimentsHelp.anchor|async)}">
             Experiments
         </a>
+        <qhana-help-tooltip label="Show help for the experiments tab." #experimentsHelp>
+            <p>
+                The experiments tab contains all known experiments.
+                Create a new experiment or import a previously exported experiment to get started.
+            </p>
+        </qhana-help-tooltip>
         <a class="navigation-link" mat-button [routerLink]="['/templates']"
-            queryParamsHandling="merge" routerLinkActive="active">
+            queryParamsHandling="merge" routerLinkActive="active"
+            [style]="{'anchor-name': '--' + (templatesHelp.anchor|async)}">
             UI Templates
         </a>
+        <qhana-help-tooltip label="Show help for the UI templates tab." #templatesHelp>
+            <p>
+                The QHAna user interface can be customized using UI Templates.
+                This tab contains all the UI Templates and allows for creating new templates or updating existing templates.
+            </p>
+        </qhana-help-tooltip>
     </ng-container>
 
     <ng-container *ngIf="(currentExperiment|async) != null">
@@ -20,7 +34,7 @@
             routerLinkActive="active" [style]="{'anchor-name': '--' + (infoHelp.anchor|async)}">
             Info
         </a>
-        <qhana-help-tooltip label="Show help for experiment info tab." #infoHelp>
+        <qhana-help-tooltip label="Show help for the experiment info tab." #infoHelp>
             <p>
                 The experiment info tab shows the basic experiment information like name and description.
                 It can also be used to change this information.
@@ -28,17 +42,38 @@
             </p>
         </qhana-help-tooltip>
         <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'workspace']"
-            queryParamsHandling="merge" routerLinkActive="active">
+            queryParamsHandling="merge" routerLinkActive="active" [style]="{'anchor-name': '--' + (workspaceHelp.anchor|async)}">
             Workspace
         </a>
+        <qhana-help-tooltip label="Show help for the experiment data tab." #workspaceHelp>
+            <p>
+                The experiment workspace allows for experiments using the available plugins to create, filter, analyze and otherwise manipulate data.
+                The available plugins are shown in the workspace sidebar to the left.
+                The plugin list is grouped by categories and can be searched.
+            </p>
+        </qhana-help-tooltip>
         <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'data']"
-            queryParamsHandling="merge" routerLinkActive="active">
+            queryParamsHandling="merge" routerLinkActive="active" [style]="{'anchor-name': '--' + (dataHelp.anchor|async)}">
             Data
         </a>
+        <qhana-help-tooltip label="Show help for the experiment data tab." #dataHelp>
+            <p>
+                Any data produced during the experiment can be found here.
+                If new data is produced with the same name, it is considered as a new version of the same data.
+            </p>
+        </qhana-help-tooltip>
         <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'timeline']"
-            queryParamsHandling="merge" routerLinkActive="active">
+            queryParamsHandling="merge" routerLinkActive="active" [style]="{'anchor-name': '--' + (timelineHelp.anchor|async)}">
             Timeline
         </a>
+        <qhana-help-tooltip label="Show help for the experiment timeline tab." #timelineHelp>
+            <p>
+                Every computation step of the experiment gets recorded in the experiment timeline.
+                Each step records its inputs and outputs, any sub-steps an execution log and more.
+                Steps can also be graded by the user to indicate how useful their result was.
+                Additionally notes can be be stored for each step.
+            </p>
+        </qhana-help-tooltip>
         <a class="navigation-link" mat-button
             [routerLink]="['/experiments', (experimentId|async), 'extra', tab.resourceKey?.uiTemplateTabId]"
             queryParamsHandling="merge" routerLinkActive="active" *ngFor="let tab of experimentExtraTabs">
@@ -66,17 +101,28 @@
 
     <div class="toolbar-spacer"></div>
 
-    <div class="experiment-switcher" [hidden]="(currentExperiment|async) == null">
+    <div class="experiment-switcher" [hidden]="(currentExperiment|async) == null" [style]="{'anchor-name': '--' + (switcherHelp.anchor|async)}">
         <span>{{currentExperiment|async}}</span>
         <a class="navigation-link" mat-icon-button [hidden]="(currentExperiment|async) == null" [routerLink]="['/']"
             aria-label="change experiment">
             <mat-icon>swap_horiz</mat-icon>
         </a>
     </div>
-    <button class="downloads-button" mat-icon-button [matMenuTriggerFor]="downloadList" aria-label="Show downloads">
+    <qhana-help-tooltip label="Show help for the experiment switcher." [hidden]="(currentExperiment|async) == null" #switcherHelp>
+        <p>
+            The experiment switcher shows the name of the current experiment and allows for switching to a different experiment.
+        </p>
+    </qhana-help-tooltip>
+    <button class="downloads-button" mat-icon-button [matMenuTriggerFor]="downloadList"
+        aria-label="Show downloads" [style]="{'anchor-name': '--' + (downloadHelp.anchor|async)}">
         <mat-icon [matBadge]="downloadBadgeCounter | async" [matBadgeHidden]="!(downloadBadgeCounter | async)"
             matBadgeColor="accent" matBadgeSize="small">download</mat-icon>
     </button>
+    <qhana-help-tooltip label="Show help for the experiment download menu." #downloadHelp>
+        <p>
+            Exported experiments will show up here once they are ready to be downloaded.
+        </p>
+    </qhana-help-tooltip>
     <mat-menu class="download" #downloadList="matMenu" yPosition="below">
         <p class="download-heading">Available downloads:</p>
         <ng-container *ngFor="let export of exportList | async; trackBy:trackExport">
@@ -99,7 +145,14 @@
         </ng-container>
     </mat-menu>
     <qhana-help-toggle></qhana-help-toggle>
-    <a class="settings-link" [routerLink]="['/settings']">
+    <a class="settings-link" [routerLink]="['/settings']" [style]="{'anchor-name': '--' + (settingsHelp.anchor|async)}">
         <mat-icon aria-hidden="false" aria-label="Settings">settings</mat-icon>
     </a>
+    <qhana-help-tooltip label="Show help for the settings page." #settingsHelp>
+        <p>
+            The settings page can be used to change various settings.
+            It contains the settings for connecting to the plugin registry.
+            It also allows editing services and environment variables stored in the plugin registry.
+        </p>
+    </qhana-help-tooltip>
 </mat-toolbar>

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -17,9 +17,16 @@
 
     <ng-container *ngIf="(currentExperiment|async) != null">
         <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'info']"
-            routerLinkActive="active">
+            routerLinkActive="active" [style]="{'anchor-name': '--' + (infoHelp.anchor|async)}">
             Info
         </a>
+        <qhana-help-tooltip label="Show help for experiment info tab." #infoHelp>
+            <p>
+                The experiment info tab shows the basic experiment information like name and description.
+                It can also be used to change this information.
+                The functions for exporting experiment data or cloning the experiment can also be found in this tab.
+            </p>
+        </qhana-help-tooltip>
         <a class="navigation-link" mat-button [routerLink]="['/experiments', (experimentId|async), 'workspace']"
             queryParamsHandling="merge" routerLinkActive="active">
             Workspace
@@ -91,6 +98,7 @@
             </div>
         </ng-container>
     </mat-menu>
+    <qhana-help-toggle></qhana-help-toggle>
     <a class="settings-link" [routerLink]="['/settings']">
         <mat-icon aria-hidden="false" aria-label="Settings">settings</mat-icon>
     </a>

--- a/src/app/services/help-service.service.ts
+++ b/src/app/services/help-service.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class HelpServiceService {
+
+    private showHelpState: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+
+    get showHelp() {
+        return this.showHelpState.asObservable();
+    }
+
+    public setShowHelp(value: boolean) {
+        this.showHelpState.next(value);
+    }
+
+    public toggleShowHelp() {
+        const current = this.showHelpState.value;
+        this.showHelpState.next(!current);
+    }
+
+}


### PR DESCRIPTION
This PR adds the components to show help directly where users might need it.
Only one proof of concept help text was added for now.

- [x] Add help for experiment navigation tabs
- [x] Add help for other nav bar tabs
- [ ] Add help for workspace sidebar
- [ ] Add help for plugin descriptions/ui in workspace
- [ ] Add help for timeline steps