### PR TITLE
Add temporary tab to display a single plugin UI tab style

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -23,6 +23,7 @@ import { ExperimentWorkspaceComponent } from './components/experiment-workspace/
 import { ExperimentComponent } from './components/experiment/experiment.component';
 import { ExperimentsPageComponent } from './components/experiments-page/experiments-page.component';
 import { PluginTabComponent } from './components/plugin-tab/plugin-tab.component';
+import { TempTabComponent } from './components/temp-tab/temp-tab.component';
 import { SettingsPageComponent } from './components/settings-page/settings-page.component';
 import { TimelineStepComponent } from './components/timeline-step/timeline-step.component';
 import { UiTemplatesPageComponent } from './components/ui-templates-page/ui-templates-page.component';
@@ -115,6 +116,7 @@ const routes: Routes = [
     { path: 'settings', component: SettingsPageComponent },
     { path: 'templates', component: UiTemplatesPageComponent },
     { path: 'templates/:templateId', component: UiTemplatesPageComponent },
+    { path: 'temp/:pluginId', component: TempTabComponent },
     { path: 'experiments', component: ExperimentsPageComponent },
     { path: 'experiments/:experimentId', redirectTo: "info" },
     { path: 'experiments/:experimentId/info', component: ExperimentComponent },
@@ -129,6 +131,7 @@ const routes: Routes = [
         matcher: extraTabsMatcher,
         component: PluginTabComponent,
     },
+    { path: 'experiments/:experimentId/temp/:pluginId', component: TempTabComponent },
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -70,6 +70,7 @@ import { MarkdownComponent } from './components/markdown/markdown.component';
 import { NavbarComponent } from './components/navbar/navbar.component';
 import { PluginSidebarComponent } from './components/plugin-sidebar/plugin-sidebar.component';
 import { PluginTabComponent } from './components/plugin-tab/plugin-tab.component';
+import { TempTabComponent } from './components/temp-tab/temp-tab.component';
 import { PluginUiframeComponent } from './components/plugin-uiframe/plugin-uiframe.component';
 import { PreviewListComponent } from './components/preview-list/preview-list.component';
 import { SettingsPageComponent } from './components/settings-page/settings-page.component';
@@ -135,6 +136,7 @@ import { HelpToggleComponent } from "src/app/components-small/help-toggle/help-t
         RawTextPreviewComponent,
         PluginPreviewComponent,
         PluginTabComponent,
+        TempTabComponent,
         ChangeUiTemplateDialog,
         TemplateDetailsComponent,
         ExperimentWorkspaceDetailComponent,

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -98,6 +98,20 @@
             </span>
         </a>
     </ng-container>
+    <ng-container *ngIf="tempTabLink != null">
+        <a class="navigation-link temporary active" mat-button [routerLink]="templateTabRouterLink()"
+            queryParamsHandling="merge" routerLinkActive="active" [style]="{'anchor-name': '--' + (tempTabHelp.anchor|async)}">
+            <span class="link-label">
+                {{tempTabLink.name ?? 'temp'}}
+            </span>
+        </a>
+        <qhana-help-tooltip label="Show help for the temporary plugin tab." #tempTabHelp>
+            <p>
+                An ephemeral tab that displays the UI of a single plugin.
+                Disappears when navigated away from.
+            </p>
+        </qhana-help-tooltip>
+    </ng-container>
 
     <div class="toolbar-spacer"></div>
 

--- a/src/app/components/navbar/navbar.component.sass
+++ b/src/app/components/navbar/navbar.component.sass
@@ -28,6 +28,10 @@
     flex-shrink: 0
     color: unset
 
+.navigation-link.temporary
+    border: 2px dotted
+    border-color: currentcolor
+
 .navigation-link:visited
     color: unset
 

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -21,6 +21,7 @@ import { CurrentExperimentService } from 'src/app/services/current-experiment.se
 import { DownloadsService } from 'src/app/services/downloads.service';
 import { ExportResult, QhanaBackendService } from 'src/app/services/qhana-backend.service';
 import { PluginRegistryBaseService } from 'src/app/services/registry.service';
+import { TempTabService } from 'src/app/services/temp-tab.service';
 import { TemplateApiObject, TemplateTabApiObject, TemplatesService } from 'src/app/services/templates.service';
 
 @Component({
@@ -52,6 +53,8 @@ export class NavbarComponent implements OnInit, OnDestroy {
 
     currentTab: ApiLink | null = null;
 
+    tempTabLink: ApiLink | null = null;
+
     routeTemplateId: string | null = null;
 
     private currentTemplateIdSubscription: Subscription | null = null;
@@ -59,8 +62,17 @@ export class NavbarComponent implements OnInit, OnDestroy {
     private templateTabUpdatesSubscription: Subscription | null = null;
     private currentTemplateTabSubscription: Subscription | null = null;
     private routeParamsSubscription: Subscription | null = null;
+    private tempTabSubscription: Subscription | null = null;
 
-    constructor(private route: ActivatedRoute, private experiment: CurrentExperimentService, private templates: TemplatesService, private registry: PluginRegistryBaseService, private backend: QhanaBackendService, private downloadService: DownloadsService) {
+    constructor(
+        private route: ActivatedRoute,
+        private experiment: CurrentExperimentService,
+        private templates: TemplatesService,
+        private registry: PluginRegistryBaseService,
+        private backend: QhanaBackendService,
+        private downloadService: DownloadsService,
+        private tempTab: TempTabService,
+    ) {
         this.currentExperiment = this.experiment.experimentName;
         this.experimentId = this.experiment.experimentId;
     }
@@ -69,6 +81,9 @@ export class NavbarComponent implements OnInit, OnDestroy {
         this.registerSubscriptions();
         this.downloadBadgeCounter = this.downloadService.getDownloadsCounter();
         this.exportList = this.downloadService.getExportList();
+        this.tempTab.tempTabPluginLink.subscribe(link => {
+            this.tempTabLink = link;
+        });
     }
 
     ngOnDestroy(): void {
@@ -77,6 +92,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
         this.templateTabUpdatesSubscription?.unsubscribe();
         this.currentTemplateTabSubscription?.unsubscribe();
         this.routeParamsSubscription?.unsubscribe();
+        this.tempTabSubscription?.unsubscribe();
     }
 
     private registerSubscriptions() {
@@ -116,6 +132,17 @@ export class NavbarComponent implements OnInit, OnDestroy {
             }
         }
         return false;
+    }
+
+    templateTabRouterLink() {
+        const routerLink = [];
+        if (this.experimentId) {
+            routerLink.push("experiments");
+            routerLink.push(this.experimentId);
+        }
+        routerLink.push("temp");
+        routerLink.push(this.tempTabLink?.resourceKey?.pluginId ?? "");
+        return routerLink;
     }
 
     private onTemplateChanges(template: TemplateApiObject | null) {

--- a/src/app/components/temp-tab/temp-tab.component.html
+++ b/src/app/components/temp-tab/temp-tab.component.html
@@ -1,0 +1,11 @@
+<qhana-plugin-uiframe class="plugin-frame" [url]="activePluginFrontendUrl"
+    [context]="{experimentId: currentExperimentId??undefined, location: 'temp'}"
+    (formDataSubmit)="onPluginUiFormSubmit($event)" (requestDataPreview)="previewData = $event"
+    *ngIf="activePluginFrontendUrl != null">
+</qhana-plugin-uiframe>
+
+<qhana-data-preview class="data-preview" [data]="previewData"
+    [context]="{experimentId: currentExperimentId??undefined, location: 'temp.data-preview'}"
+    *ngIf="previewData">
+    <h3 class="t-headline">Preview "{{previewData.name}}"</h3>
+</qhana-data-preview>

--- a/src/app/components/temp-tab/temp-tab.component.html
+++ b/src/app/components/temp-tab/temp-tab.component.html
@@ -1,3 +1,4 @@
+<div class="tab-content {{previewData ? 'with-preview' : ''}}">
 <qhana-plugin-uiframe class="plugin-frame" [url]="activePluginFrontendUrl"
     [context]="{experimentId: currentExperimentId??undefined, location: 'temp'}"
     (formDataSubmit)="onPluginUiFormSubmit($event)" (requestDataPreview)="previewData = $event"
@@ -9,3 +10,4 @@
     *ngIf="previewData">
     <h3 class="t-headline">Preview "{{previewData.name}}"</h3>
 </qhana-data-preview>
+</div>

--- a/src/app/components/temp-tab/temp-tab.component.sass
+++ b/src/app/components/temp-tab/temp-tab.component.sass
@@ -1,0 +1,8 @@
+.tab-content
+    display: grid
+    grid-template-columns: 1fr
+    grid-template-rows: 1fr
+    gap: 0.5rem
+
+.tab-content.with-preview
+    grid-template-columns: minmax(60rem, 2fr) minmax(20rem, 1fr)

--- a/src/app/components/temp-tab/temp-tab.component.ts
+++ b/src/app/components/temp-tab/temp-tab.component.ts
@@ -1,0 +1,142 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { ApiLink, PageApiObject } from 'src/app/services/api-data-types';
+import { CurrentExperimentService } from 'src/app/services/current-experiment.service';
+import { PluginApiObject } from 'src/app/services/qhana-api-data-types';
+import { ExperimentDataApiObject, QhanaBackendService } from 'src/app/services/qhana-backend.service';
+import { PluginRegistryBaseService } from 'src/app/services/registry.service';
+import { TempTabService } from 'src/app/services/temp-tab.service';
+import { FormSubmitData } from '../plugin-uiframe/plugin-uiframe.component';
+
+@Component({
+    selector: 'qhana-temp-tab',
+    templateUrl: './temp-tab.component.html',
+    styleUrl: './temp-tab.component.sass'
+})
+export class TempTabComponent implements OnInit, OnDestroy {
+
+    private routeParamsSubscription: Subscription | null = null;
+    private queryParamsSubscription: Subscription | null = null;
+
+    private templateParam: string | undefined;
+
+    extraParams: Map<string, string> | null = null;
+
+    currentPluginId: string | null = null;
+    currentExperimentId: string | null = null;
+
+    activePluginLink: ApiLink | null = null;
+    activePluginFrontendUrl: string | null = null;
+
+    previewData: ExperimentDataApiObject | null = null;
+
+    constructor(private tempTab: TempTabService, private route: ActivatedRoute, private router: Router, private registry: PluginRegistryBaseService, private backend: QhanaBackendService, private experiment: CurrentExperimentService) { }
+
+
+    ngOnInit(): void {
+        this.routeParamsSubscription = this.route.params.subscribe(params => {
+            this.currentExperimentId = params?.experimentId ?? null;
+            this.experiment.setExperimentId(params?.experimentId ?? null);
+            this.currentPluginId = params?.pluginId ?? null;
+            this.onParamsChanged();
+        });
+        this.queryParamsSubscription = this.route.queryParamMap.subscribe(params => {
+            this.templateParam = params.get("template") ?? undefined;
+            const extraParams = new Map<string, string>();
+            params.keys.forEach(key => {
+                if (key.startsWith("param-")) {
+                    const value = params.get(key);
+                    if (value) {
+                        extraParams.set(key.substring(6), value);
+                    }
+                }
+            })
+            if (extraParams.size > 0) {
+                this.extraParams = extraParams;
+            } else {
+                this.extraParams = null;
+            }
+        });
+    }
+
+    ngOnDestroy(): void {
+        this.routeParamsSubscription?.unsubscribe();
+        this.queryParamsSubscription?.unsubscribe();
+        this.tempTab.setTempTabPluginLink(null);
+    }
+
+    private async onParamsChanged() {
+        const pluginId = this.currentPluginId;
+        if (pluginId == null) {
+            this.activePluginFrontendUrl = null;
+            this.activePluginLink = null;
+            this.tempTab.setTempTabPluginLink(null);
+            return;
+        }
+
+        let pluginLink: ApiLink | null = null;
+
+        const query = new URLSearchParams({ "plugin-id": pluginId });
+        const page = await this.registry.getByRel<PageApiObject>([["plugin", "collection"]], query, true);
+        if (page?.data?.items?.[0]?.resourceKey?.pluginId === pluginId) {
+            pluginLink = page.data.items[0];
+        }
+
+        if (pluginLink == null) {
+            this.activePluginFrontendUrl = null;
+            this.activePluginLink = null;
+            this.tempTab.setTempTabPluginLink(null);
+            return;
+        }
+
+        const pluginResponse = await this.registry.getByApiLink<PluginApiObject>(pluginLink);
+        const nextUrl = pluginResponse?.data?.entryPoint?.uiHref ?? null;
+
+        if (nextUrl == null) {
+            this.activePluginFrontendUrl = null;
+            this.activePluginLink = null;
+            this.tempTab.setTempTabPluginLink(null);
+            return;
+        }
+
+        const parsed = new URL(nextUrl, pluginResponse?.data?.self?.href);
+        const extraParams = this.extraParams;
+        if (extraParams != null) {
+            extraParams.forEach((value, param) => {
+                parsed.searchParams.set(param, value);
+            });
+        }
+        this.activePluginFrontendUrl = parsed.toString();
+        this.activePluginLink = pluginLink;
+        this.tempTab.setTempTabPluginLink(pluginLink);
+    }
+
+    async onPluginUiFormSubmit(formData: FormSubmitData) {
+        const experimentId = this.currentExperimentId;
+        if (experimentId == null) {
+            return;  // only allow submit in experiment navigation tabs
+        }
+        const pluginLink = this.activePluginLink;
+        if (pluginLink == null) {
+            return;
+        }
+        const plugin = (await this.registry.getByApiLink<PluginApiObject>(pluginLink, null, false))?.data ?? null;
+        if (plugin == null) {
+            return; //plugin was removed from registry
+        }
+        this.backend.createTimelineStep(experimentId, {
+            inputData: formData.dataInputs,
+            parameters: formData.formData,
+            parametersContentType: formData.formDataType,
+            processorLocation: plugin.href,
+            processorName: plugin.identifier,
+            processorVersion: plugin.version,
+            resultLocation: formData.resultUrl,
+        }).subscribe(timelineStep => this.router.navigate(
+            ['/experiments', experimentId, 'timeline', timelineStep.sequence.toString()],
+            { queryParams: (this.templateParam != null) ? { "template": this.templateParam } : {} }
+        ));
+    }
+
+}

--- a/src/app/services/temp-tab.service.ts
+++ b/src/app/services/temp-tab.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { ApiLink } from './api-data-types';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class TempTabService {
+
+    private tempTabPlugin: BehaviorSubject<ApiLink | null> = new BehaviorSubject<ApiLink | null>(null);
+
+    get tempTabPluginLink() {
+        return this.tempTabPlugin.asObservable();
+    }
+
+    public setTempTabPluginLink(value: ApiLink | null) {
+        this.tempTabPlugin.next(value);
+    }
+
+}

--- a/src/styles.sass
+++ b/src/styles.sass
@@ -257,6 +257,7 @@ $my-typography: mat.define-typography-config()
 
 html, body
     height: 100%
+    height: stretch
 
 body
     margin: 0


### PR DESCRIPTION
Adds a temporary tab to the navigation bar (only shows up while active) to display a single plugin UI outside of the workspace without requiring UI templates.

- [x] basic functionality
- [x] test plugin ui submit
- [x] test styles for plugin ui and preview